### PR TITLE
Update CtClassType.java

### DIFF
--- a/src/main/javassist/CtClassType.java
+++ b/src/main/javassist/CtClassType.java
@@ -667,18 +667,26 @@ class CtClassType extends CtClass {
         return result;
     }
 
-    private static Object toAnnoType(Annotation anno, ClassPool cp)
+   private static Object toAnnoType(Annotation anno, ClassPool cp)
         throws ClassNotFoundException
     {
         try {
+          return AnnotationImpl.make(cp.getClassLoader(),
+                        cp.get(anno.getTypeName()).toClass(),
+                        cp, anno);
+        }
+        catch (Exception e) {
+          try {
             ClassLoader cl = cp.getClassLoader();
             return anno.toAnnotationType(cl, cp);
-        }
-        catch (ClassNotFoundException e) {
+          }
+          catch (ClassNotFoundException e1) {
             ClassLoader cl2 = cp.getClass().getClassLoader();
             return anno.toAnnotationType(cl2, cp);
+          }
         }
     }
+
 
     public boolean subclassOf(CtClass superclass) {
         if (superclass == null)


### PR DESCRIPTION
Following our conversation by mail, I send you a pull request that allows to use the ClassPool to load annotation types.

The problem I have is that the current implementation only uses the ClassPool's classloader, and this class loader is not aware (in my case) of the types known by the ClassPool itself. This feature is reall important for some of the projects you can find here : https://github.com/stephanenicolas/injects/.

My main concern is to get a configuration free plugin for Transforming Android classes during gradle builds and the current implementation of Javassist for loading classes would require an extra configuration, a bit difficult, to the end users to make sure the plugin knows about the annotations they use (which is not only complex but really awkward as other classes are loaded fine).

I can rework the PR to your convenience as I would really appreciate to get that merged in next release.
