### PR TITLE
Support Javaflow NEW bytecode pattern for replacement.

### DIFF
--- a/src/main/javassist/expr/NewExpr.java
+++ b/src/main/javassist/expr/NewExpr.java
@@ -140,8 +140,9 @@ public class NewExpr extends Expr {
 
     private int canReplace() throws CannotCompileException {
         int op = iterator.byteAt(newPos + 3);
-        if (op == Opcode.DUP)
-            return 4;
+        if (op == Opcode.DUP)     // Typical single DUP or Javaflow DUP DUP2_X2 POP2
+            return ((iterator.byteAt(newPos + 4) == Opcode.DUP2_X2
+                 && iterator.byteAt(newPos + 5) == Opcode.POP2)) ? 6 : 4;
         else if (op == Opcode.DUP_X1
                  && iterator.byteAt(newPos + 4) == Opcode.SWAP)
             return 5;


### PR DESCRIPTION
Patch to support Javaflow NEW bytecode pattern so that Javassist replacement will not corrupt the stack of a class file already instrumented by Javaflow. See javassist#20 for details.
