### PR TITLE
Update maven-jar-plugin and maven-compiler-plugin to fix warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -160,6 +161,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.sourceDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
The following warning when invoking `mvn versions:display-plugin-updates` does not appear anymore:
```
[WARNING] Some problems were encountered while building the effective model for org.javassist:javassist:bundle:3.19.0-GA
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 137, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 160, column 15
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```