### PR TITLE
New Function CtClass#removeNestedClass(String) to remove an InnerClass

### DIFF
--- a/src/main/javassist/CtClass.java
+++ b/src/main/javassist/CtClass.java
@@ -660,6 +660,17 @@ public abstract class CtClass {
         return new CtClass[0];
     }
 
+    
+    /**
+     * Removes all Inner Class Attribute
+     * when the InnerName of attribute matches name.
+     * 
+     * @param name
+     */
+    public void removeNestedClass( String name ){
+    }
+
+
     /**
      * Sets the modifiers.
      *
@@ -807,6 +818,7 @@ public abstract class CtClass {
     public CtClass makeNestedClass(String name, boolean isStatic) {
         throw new RuntimeException(getName() + " is not a class");
     }
+
 
     /**
      * Returns an array containing <code>CtField</code> objects

--- a/src/main/javassist/CtClassType.java
+++ b/src/main/javassist/CtClassType.java
@@ -437,7 +437,34 @@ class CtClassType extends CtClass {
         return (CtClass[])list.toArray(new CtClass[list.size()]);
     }
 
-    public void setModifiers(int mod) {
+    @Override
+	public void removeNestedClass(String nameS) {
+    	
+        ClassFile cf = getClassFile2();
+        InnerClassesAttribute ica
+            = (InnerClassesAttribute)cf.getAttribute(InnerClassesAttribute.tag);
+        if (ica == null) {
+        	return;
+        }
+
+        AGAIN:
+        while ( true ){
+        	int n = ica.tableLength();
+        	for (int i = 0; i < n; i++) {
+        		String name = ica.innerClass(i);
+        		if ( nameS.equals(name) ){
+        			checkModify();
+        			gcConstPool = true;
+        			ica.remove(i);
+        			continue AGAIN;//try again when removal occurs.
+        		}
+        	}
+        	break;
+        }
+        return;
+	}
+
+	public void setModifiers(int mod) {
         ClassFile cf = getClassFile2();
         if (Modifier.isStatic(mod)) {
             int flags = cf.getInnerAccessFlags();

--- a/src/main/javassist/bytecode/InnerClassesAttribute.java
+++ b/src/main/javassist/bytecode/InnerClassesAttribute.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 
 /**
  * <code>InnerClasses_attribute</code>.
+ * 
+ * @see jvms-4.7.6 The InnerClasses Attribute
  */
 public class InnerClassesAttribute extends AttributeInfo {
     /**
@@ -195,6 +197,54 @@ public class InnerClassesAttribute extends AttributeInfo {
         ByteArray.write16bit(flags, newData, len + 6);
 
         set(newData);
+    }
+    
+    /**
+     * Set <code>number_of_classes</code> = 0 and then
+     * trim the <code>classes</code> records into 0 length.
+     */
+	public void clear(){
+        byte[] ndata =  new byte[2];
+        ByteArray.write16bit(0, ndata, 0);
+        set(ndata);
+    }
+    
+
+	/**
+	 * Remove the <code>classes[nth]</code> record.
+	 * The constant pool for <code>classes[nth]</code> is left unreleased in this version.
+	 * 
+	 * @param nth
+	 */
+    public void remove(int nth ){
+    	//original size
+    	int n = tableLength();
+    	//new size
+    	int N = n - 1;
+        
+        int[] innerClass = new int[N];
+        int[] outerClass = new int[N];
+        int[] name = new int[N];
+        int[] flags = new int[N];
+        
+        for ( int i = 0, I = 0; i < n; i ++ ){
+        	if ( i == nth )  continue;
+        	innerClass[I] = innerClassIndex(i);
+        	outerClass[I] = outerClassIndex(i);
+        	name[I] = innerNameIndex(i);
+        	flags[I] = accessFlags(i);
+        	I++;
+        }
+        
+        clear();
+        
+        for ( int i = 0; i < N; i ++ ){
+        	append(
+        			innerClass[i],
+        			outerClass[i],
+        			name[i],
+        			flags[i]);
+        }
     }
 
     /**

--- a/src/test/test3/InnerRemoval.java
+++ b/src/test/test3/InnerRemoval.java
@@ -1,0 +1,21 @@
+package test3;
+
+public class InnerRemoval {
+	public class InPublicNonStatic{
+	}
+	private class InPrivateNonStatic{
+	}
+	class InPackageNonStatic{
+	}
+	protected class InProtectedNonStatic{
+	}
+	
+	public static class InPublicStatic{
+	}
+	private static class InPrivateStatic{
+	}
+	static class InPackageStatic{
+	}
+	protected static class InProtectedStatic{
+	}
+}


### PR DESCRIPTION
I want to use the javassist to shrink my code becuase  the quality of defacto shrinker in java is not so reliable at least in java 8. I wrote a new Function to remove a signature of InnerClass in a java class. This function is a very basic operation for byte code shrinker to shrink the inner-class relation. I also wrote some tests for new function.