### PR TITLE
Generic is not supported by JDK under 1.5 version

### DIFF
--- a/src/main/javassist/tools/Callback.java
+++ b/src/main/javassist/tools/Callback.java
@@ -48,7 +48,7 @@ import java.util.UUID;
  */
 public abstract class Callback {
 
-    public static HashMap<String, Callback> callbacks = new HashMap<String, Callback>();
+    public static HashMap callbacks = new HashMap();
 
     private final String sourceCode;
 
@@ -70,9 +70,8 @@ public abstract class Callback {
      *
      * @param objects   Objects that the bytecode in callback returns
      */
-    public abstract void result(Object... objects);
+    public abstract void result(Object[] objects);
 
-    @Override
     public String toString(){
         return sourceCode();
     }


### PR DESCRIPTION
When try to compile using JDK 1.4 that's failed due to the Generic.