### PR TITLE
hasAnnotation(String clazzName) method is required instead of hasAnnotation(Class) #51

### DIFF
--- a/src/main/javassist/CtBehavior.java
+++ b/src/main/javassist/CtBehavior.java
@@ -161,12 +161,12 @@ public abstract class CtBehavior extends CtMember {
     /**
      * Returns true if the class has the specified annotation class.
      *
-     * @param clz the annotation class.
+     * @param clz the name of annotation class.
      * @return <code>true</code> if the annotation is found,
      *         otherwise <code>false</code>.
      * @since 3.11
      */
-    public boolean hasAnnotation(Class clz) {
+    public boolean hasAnnotation(String clz) {
        MethodInfo mi = getMethodInfo2();
        AnnotationsAttribute ainfo = (AnnotationsAttribute)
                    mi.getAttribute(AnnotationsAttribute.invisibleTag);  

--- a/src/main/javassist/CtClass.java
+++ b/src/main/javassist/CtClass.java
@@ -589,6 +589,17 @@ public abstract class CtClass {
      * @since 3.11
      */
     public boolean hasAnnotation(Class clz) {
+        return hasAnnotation(clz.getName());
+    }
+
+    /**
+     * Returns true if the class has the specified annotation class.
+     *
+     * @param annotClzName the name of annotation class.
+     * @return <code>true</code> if the annotation is found, otherwise <code>false</code>.
+     * @since 3.11
+     */
+    public boolean hasAnnotation(String annotClzName) {
         return false;
     }
 

--- a/src/main/javassist/CtClassType.java
+++ b/src/main/javassist/CtClassType.java
@@ -451,17 +451,26 @@ class CtClassType extends CtClass {
         cf.setAccessFlags(AccessFlag.of(mod));
     }
 
-    public boolean hasAnnotation(Class clz) {
+    //@Override
+    public boolean hasAnnotation(String annotClzName) {
         ClassFile cf = getClassFile2();
         AnnotationsAttribute ainfo = (AnnotationsAttribute)
-                cf.getAttribute(AnnotationsAttribute.invisibleTag);  
+                cf.getAttribute(AnnotationsAttribute.invisibleTag);
         AnnotationsAttribute ainfo2 = (AnnotationsAttribute)
-                cf.getAttribute(AnnotationsAttribute.visibleTag);  
-        return hasAnnotationType(clz, getClassPool(), ainfo, ainfo2);
+                cf.getAttribute(AnnotationsAttribute.visibleTag);
+        return hasAnnotationType(annotClzName, getClassPool(), ainfo, ainfo2);
     }
 
     static boolean hasAnnotationType(Class clz, ClassPool cp,
-                                     AnnotationsAttribute a1, AnnotationsAttribute a2)
+                                     AnnotationsAttribute a1,
+                                     AnnotationsAttribute a2)
+    {
+        return hasAnnotationType(clz.getName(), cp, a1, a2);
+    }
+
+    static boolean hasAnnotationType(String annotationClzNm, ClassPool cp,
+                                     AnnotationsAttribute a1,
+                                     AnnotationsAttribute a2)
     {
         Annotation[] anno1, anno2;
 
@@ -475,16 +484,17 @@ class CtClassType extends CtClass {
         else
             anno2 = a2.getAnnotations();
 
-        String typeName = clz.getName();
+        //        String typeName = clz.getName();
+        String typeName = annotationClzNm;
         if (anno1 != null)
-           for (int i = 0; i < anno1.length; i++)
-              if (anno1[i].getTypeName().equals(typeName))
-                  return true;
+            for (int i = 0; i < anno1.length; i++)
+                if (anno1[i].getTypeName().equals(typeName))
+                    return true;
 
         if (anno2 != null)
-           for (int i = 0; i < anno2.length; i++)
-              if (anno2[i].getTypeName().equals(typeName))
-                  return true;
+            for (int i = 0; i < anno2.length; i++)
+                if (anno2[i].getTypeName().equals(typeName))
+                    return true;
 
         return false;
     }

--- a/src/main/javassist/CtField.java
+++ b/src/main/javassist/CtField.java
@@ -244,11 +244,11 @@ public class CtField extends CtMember {
     /**
      * Returns true if the class has the specified annotation class.
      *
-     * @param clz the annotation class.
+     * @param clz the name of annotation class.
      * @return <code>true</code> if the annotation is found, otherwise <code>false</code>.
      * @since 3.11
      */
-    public boolean hasAnnotation(Class clz) {
+    public boolean hasAnnotation(String clz) {
         FieldInfo fi = getFieldInfo2();
         AnnotationsAttribute ainfo = (AnnotationsAttribute)
                     fi.getAttribute(AnnotationsAttribute.invisibleTag);  

--- a/src/main/javassist/CtMember.java
+++ b/src/main/javassist/CtMember.java
@@ -30,7 +30,7 @@ public abstract class CtMember {
      */
     static class Cache extends CtMember {
         protected void extendToString(StringBuffer buffer) {}
-        public boolean hasAnnotation(Class clz) { return false; }
+        public boolean hasAnnotation(String clz) { return false; }
         public Object getAnnotation(Class clz)
             throws ClassNotFoundException { return null; }
         public Object[] getAnnotations()
@@ -214,7 +214,18 @@ public abstract class CtMember {
      * @return <code>true</code> if the annotation is found, otherwise <code>false</code>.
      * @since 3.11
      */
-    public abstract boolean hasAnnotation(Class clz);
+    public boolean hasAnnotation(Class clz) {
+        return hasAnnotation(clz.getName());
+    }
+
+    /**
+     * Returns true if the class has the specified annotation class.
+     *
+     * @param annotClzName the name of annotation class.
+     * @return <code>true</code> if the annotation is found, otherwise <code>false</code>.
+     * @since 3.11
+     */
+    public abstract boolean hasAnnotation(String annotClzName);
 
     /**
      * Returns the annotation if the class has the specified annotation class.

--- a/src/test/javassist/JvstTest4.java
+++ b/src/test/javassist/JvstTest4.java
@@ -101,6 +101,10 @@ public class JvstTest4 extends JvstTestRoot {
 
         assertTrue(cc.hasAnnotation(test4.Anno1.class));
         assertFalse(cc.hasAnnotation(java.lang.annotation.Documented.class));
+        
+        assertTrue(cc.hasAnnotation(test4.Anno1.class.getName()));
+        assertFalse(cc.hasAnnotation(java.lang.annotation.Documented.class.getName()));
+        
         assertEquals("empty", ((test4.Anno1)cc.getAnnotation(test4.Anno1.class)).value());
         assertNull(cc.getAnnotation(Deprecated.class));
 


### PR DESCRIPTION
new APIs of hasAnnotation(String) in classes of Ct*. It can be used to avoid a Classloader Hell or to reduce amount of permgen memory.