### PR TITLE
Improvement Rebuid StackMap

### DIFF
--- a/Readme.html
+++ b/Readme.html
@@ -283,7 +283,7 @@ see javassist.Dump.
 
 <p>-version 3.21
 <ul>
-<li>JIRA JASSIST-244, 248, 255
+<li>JIRA JASSIST-244, 245, 248, 255
 </ul>
 </p>
 

--- a/Readme.html
+++ b/Readme.html
@@ -283,7 +283,7 @@ see javassist.Dump.
 
 <p>-version 3.21
 <ul>
-<li>JIRA JASSIST-244, 248
+<li>JIRA JASSIST-244, 248, 255
 </ul>
 </p>
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
           <target>1.6</target>
           <testSource>1.8</testSource>
           <testTarget>1.8</testTarget>
-          <compilerArgument>-parameters</compilerArgument>
+          <testCompilerArgument>-parameters</testCompilerArgument>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/javassist/compiler/CodeGen.java
+++ b/src/main/javassist/compiler/CodeGen.java
@@ -1420,12 +1420,13 @@ public abstract class CodeGen extends Visitor implements Opcode, TokenId {
         int type = expr.getType();
         oprand.accept(this);
         int srcType = exprType;
+        int srcDim = arrayDim;
         if (invalidDim(srcType, arrayDim, className, type, dim, name, true)
             || srcType == VOID || type == VOID)
             throw new CompileError(msg);
 
         if (type == CLASS) {
-            if (!isRefType(srcType))
+            if (!isRefType(srcType) && srcDim == 0)
                 throw new CompileError(msg);
 
             return toJvmArrayName(name, dim);

--- a/src/test/javassist/JvstTest5.java
+++ b/src/test/javassist/JvstTest5.java
@@ -135,4 +135,11 @@ public class JvstTest5 extends JvstTestRoot {
         Object obj = make(cc.getName());
         assertEquals(40271, invoke(obj, "run"));
     }
+
+    public void testInvalidCastWithDollar() throws Exception {
+        String code = "{ new JavassistInvalidCastTest().inspectReturn((Object) ($w) $_); } ";
+        CtClass c = sloader.get("test5.InvalidCastDollar");
+        for (CtMethod method : c.getDeclaredMethods())
+            method.insertAfter(code);
+    }
 }

--- a/src/test/test5/InvalidCastDollar.java
+++ b/src/test/test5/InvalidCastDollar.java
@@ -1,0 +1,11 @@
+package test5;
+
+public class InvalidCastDollar {
+    public static byte[] arrayReturn() {
+        return new byte[12];
+    }
+
+    public static int intReturn() {
+        return 23;
+    }
+}

--- a/tutorial/tutorial2.html
+++ b/tutorial/tutorial2.html
@@ -481,7 +481,8 @@ compiled code at the end of the method.  In the statement given to
 available.
 
 <p>The variable <code>$_</code> represents the resulting value of the
-method.  The type of that variable is the type of the result type (the
+method.  So it is a write-only variable.
+The type of that variable is the type of the result type (the
 return type) of the method.  If the result type is <code>void</code>,
 then the type of <code>$_</code> is <code>Object</code> and the value
 of <code>$_</code> is <code>null</code>.

--- a/tutorial/tutorial2.html
+++ b/tutorial/tutorial2.html
@@ -481,7 +481,7 @@ compiled code at the end of the method.  In the statement given to
 available.
 
 <p>The variable <code>$_</code> represents the resulting value of the
-method.  So it is a write-only variable.
+method.
 The type of that variable is the type of the result type (the
 return type) of the method.  If the result type is <code>void</code>,
 then the type of <code>$_</code> is <code>Object</code> and the value


### PR DESCRIPTION
When try rebuild StackMap can be thrown NotFoundException if some reference classes were not loaded yet NotFoundException. 

How about try make not loaded class using makeClass method of ClassPool?