### PR TITLE
Improvement rebuildStackMap

### DIFF
--- a/src/main/javassist/bytecode/stackmap/TypeData.java
+++ b/src/main/javassist/bytecode/stackmap/TypeData.java
@@ -334,6 +334,24 @@ public abstract class TypeData {
                 }
             }
         }
+        
+        private CtClass getOrMakeCtClassIfNotLoadedYet(ClassPool cp, String className) throws NotFoundException
+        {
+            CtClass cc;
+            try
+            {
+                cc = cp.get(className);
+            }
+            catch (NotFoundException e)
+            {
+                cc = cp.makeClass(className);
+                if (cc == null) {
+                    throw e;
+                }
+            }
+
+            return cc;
+        }
 
         private String fixTypes2(ArrayList scc, HashSet lowersSet, ClassPool cp) throws NotFoundException {
             Iterator it = lowersSet.iterator();
@@ -341,18 +359,25 @@ public abstract class TypeData {
                 return null;      // only NullType
             else if (lowersSet.size() == 1)
                 return (String)it.next(); 
-            else {
-            	CtClass cc = cp.get((String)it.next());
-            	while (it.hasNext())
-            		cc = commonSuperClassEx(cc, cp.get((String)it.next()));
+            else
+            {
+                String className = (String) it.next();
+                CtClass cc = getOrMakeCtClassIfNotLoadedYet(cp, className);
 
-            	if (cc.getSuperclass() == null || isObjectArray(cc))
-            	    cc = fixByUppers(scc, cp, new HashSet(), cc);
+                while (it.hasNext())
+                {
+                    className = (String) it.next();
+                    CtClass tmp = getOrMakeCtClassIfNotLoadedYet(cp, className);
+                    cc = commonSuperClassEx(cc, tmp);
+                }
 
-            	if (cc.isArray())
-            	    return Descriptor.toJvmName(cc);
-            	else
-            	    return cc.getName();
+                if (cc.getSuperclass() == null || isObjectArray(cc))
+                { cc = fixByUppers(scc, cp, new HashSet(), cc); }
+
+                if (cc.isArray())
+                { return Descriptor.toJvmName(cc); }
+                else
+                { return cc.getName(); }
             }
         }
 
@@ -375,7 +400,8 @@ public abstract class TypeData {
                 if (t.uppers != null) {
                     int s = t.uppers.size();
                     for (int k = 0; k < s; k++) {
-                        CtClass cc = cp.get((String)t.uppers.get(k));
+                        String className = (String)t.uppers.get(k);
+                        CtClass cc = getOrMakeCtClassIfNotLoadedYet(cp, className);
                         if (cc.subtypeOf(type))
                             type = cc;
                     }


### PR DESCRIPTION
When try rebuild StackMap can be thrown NotFoundException if some reference classes were not loaded yet NotFoundException.
How about try make not loaded class using makeClass method of ClassPool?

This situation occurred not rarely in IBM JDK environment.
I was face with it in IBM Liberty with IBM JDK 8.

After fix it rebuildStackMap working properly.
How do you think about it?