### PR TITLE
Improvement rebuild StackMap (CtClassType change)

### DIFF
--- a/src/main/javassist/CtClassType.java
+++ b/src/main/javassist/CtClassType.java
@@ -192,7 +192,24 @@ class CtClassType extends CtClass {
         try {
             fin = classPool.openClassfile(getName());
             if (fin == null)
-                throw new NotFoundException(getName());
+            {
+                CtClass tmp = classPool.makeClass(getName());
+
+                if (tmp == null)
+                {
+                    throw new NotFoundException(getName());
+                }
+                else
+                {
+                    try
+                    {
+                        fin = new ByteArrayInputStream(tmp.toBytecode());
+                    }
+                    catch (CannotCompileException e)
+                    {
+                    }
+                }
+            }    
 
             fin = new BufferedInputStream(fin);
             ClassFile cf = new ClassFile(new DataInputStream(fin));
@@ -732,8 +749,25 @@ class CtClassType extends CtClass {
         String supername = getClassFile2().getSuperclass();
         if (supername == null)
             return null;
-        else
-            return classPool.get(supername);
+        else    
+        {
+            try
+            {
+                return classPool.get(supername);
+            }
+            catch (NotFoundException notFoundException)
+            {
+                CtClass superClass = classPool.makeClass(supername);
+                if (superClass == null)
+                {
+                    throw notFoundException;
+                }
+                else
+                {
+                    return superClass;
+                }
+            }
+        }
     }
 
     public void setSuperclass(CtClass clazz) throws CannotCompileException {


### PR DESCRIPTION
When try rebuild StackMap can be thrown NotFoundException if some reference classes were not loaded yet NotFoundException.
How about try make not loaded class using makeClass method of ClassPool?

This situation occurred not rarely in IBM JDK environment.
I was face with it in IBM Liberty with IBM JDK 8.

After fix it rebuildStackMap working properly.
How do you think about it?
