### PR TITLE
Fix NullPointerException in ControlFlow constructor

### DIFF
--- a/src/main/javassist/bytecode/analysis/ControlFlow.java
+++ b/src/main/javassist/bytecode/analysis/ControlFlow.java
@@ -71,6 +71,8 @@ public class ControlFlow {
                 return new Block[size];
             }
         }.make(minfo);
+        if (basicBlocks == null)
+            basicBlocks = new Block[0];
         int size = basicBlocks.length;
         int[] counters = new int[size];
         for (int i = 0; i < size; i++) {
@@ -97,6 +99,9 @@ public class ControlFlow {
 
     /**
      * Returns all the basic blocks in the method body.
+     *
+     * @return an array of basic blocks, the array has length 0 if
+     * the method doesn't have code.
      */
     public Block[] basicBlocks() {
         return basicBlocks;
@@ -133,7 +138,7 @@ public class ControlFlow {
      * For every array element <code>node</code>, its index in the
      * array is equivalent to <code>node.block().index()</code>. 
      *
-     * @return an array of the tree nodes, or null if the method is abstract.
+     * @return an array of the tree nodes, or null if the method doesn't have code.
      * @see Node#block()
      * @see Block#index()
      */
@@ -179,7 +184,7 @@ public class ControlFlow {
      * For every array element <code>node</code>, its index in the
      * array is equivalent to <code>node.block().index()</code>.
      *
-     * @return an array of the tree nodes, or null if the method is abstract.
+     * @return an array of the tree nodes, or null if the method doesn't have code.
      * @see Node#block()
      * @see Block#index()
      */


### PR DESCRIPTION
An NPE would be thrown by the constructor when called with a method without code.
Also clarify the documentation of a few methods.