### PR TITLE
removal of annotations

### DIFF
--- a/src/main/javassist/bytecode/AnnotationsAttribute.java
+++ b/src/main/javassist/bytecode/AnnotationsAttribute.java
@@ -214,6 +214,29 @@ public class AnnotationsAttribute extends AttributeInfo {
     }
 
     /**
+     * Removes an annotation by type.
+     *
+     * @param type        of annotation to remove
+     * @return whether an annotation with the given type has been removed
+     */
+    public boolean removeAnnotation(String type) {
+        Annotation[] annotations = getAnnotations();
+        for (int i = 0; i < annotations.length; i++) {
+            if (annotations[i].getTypeName().equals(type)) {
+                Annotation[] newlist = new Annotation[annotations.length - 1];
+                System.arraycopy(annotations, 0, newlist, 0, i);
+                if (i < annotations.length - 1) {
+                    System.arraycopy(annotations, i + 1, newlist, i,
+                                     annotations.length - i - 1);
+                }
+                setAnnotations(newlist);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Parses the annotations and returns a data structure representing
      * that parsed annotations.  Note that changes of the node values of the
      * returned tree are not reflected on the annotations represented by


### PR DESCRIPTION
I've implemented a method `AnnotationsAttribute.removeAnnotation(String type)`. The implementation is inspired by [apache commons-lang](https://github.com/apache/commons-lang/blob/master/src/main/java/org/apache/commons/lang3/ArrayUtils.java#L6495) and does not rely on converting back and forth to collections/streams.

This PR resolves issue #75.