### PR TITLE
Update ClassFile.java

### DIFF
--- a/src/main/javassist/bytecode/ClassFile.java
+++ b/src/main/javassist/bytecode/ClassFile.java
@@ -146,7 +146,7 @@ public final class ClassFile {
             ver = JAVA_5;
             Class.forName("java.util.zip.DeflaterInputStream");
             ver = JAVA_6;
-            Class.forName("java.lang.invoke.CallSite");
+            Class.forName("java.lang.invoke.CallSite", false, ClassLoader.getSystemClassLoader());
             ver = JAVA_7;
             Class.forName("java.util.function.Function");
             ver = JAVA_8;


### PR DESCRIPTION
A fix for older JDK8 versions: https://bugs.openjdk.java.net/browse/JDK-8041920
This caused random failures a little time after startup. Reported now so that when we upgrade javassist for JDK9 then we would not have to fork this class.