### PR TITLE
Junit migrate ver 3 to 4 and squash some maven warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,9 @@
   <name>Javassist</name>
   <url>http://www.javassist.org/</url>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <organization>
     <name>Shigeru Chiba, www.javassist.org</name>
   </organization>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
             <include>javassist/JvstTest.java</include>
           </includes>
 	  <forkMode>once</forkMode>
-          <workingDirectory>runtest</workingDirectory>
+      <workingDirectory>${project.build.directory}/runtest</workingDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>

--- a/pom.xml
+++ b/pom.xml
@@ -304,10 +304,16 @@
   </profiles>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-all</artifactId>
+        <version>1.3</version>
+        <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/test/javassist/Bench.java
+++ b/src/test/javassist/Bench.java
@@ -153,11 +153,6 @@ public class Bench extends JvstTestRoot {
         System.out.println("println: " + (t5 * 10) + " usec");
     }
 
-    public static void main(String[] args) {
-        // junit.textui.TestRunner.run(suite());
-        junit.swingui.TestRunner.main(new String[] { "javassist.Bench" });
-    }
-
     public static Test suite() {
         TestSuite suite = new TestSuite("Benchmark Tests");
         suite.addTestSuite(Bench.class);

--- a/src/test/javassist/JvstTest2.java
+++ b/src/test/javassist/JvstTest2.java
@@ -2,10 +2,15 @@ package javassist;
 
 import java.io.*;
 import java.net.URL;
+
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+
 import java.lang.reflect.Method;
 
 import javassist.expr.*;
 
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class JvstTest2 extends JvstTestRoot {
     public JvstTest2(String name) {
          super(name);

--- a/src/test/javassist/JvstTest4.java
+++ b/src/test/javassist/JvstTest4.java
@@ -6,10 +6,14 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.HashSet;
 
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+
 import javassist.bytecode.*;
 import javassist.bytecode.annotation.Annotation;
 import javassist.expr.*;
 
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class JvstTest4 extends JvstTestRoot {
     public JvstTest4(String name) {
         super(name);

--- a/src/test/javassist/JvstTest4.java
+++ b/src/test/javassist/JvstTest4.java
@@ -628,7 +628,7 @@ public class JvstTest4 extends JvstTestRoot {
         assertEquals(packageName, obj.getClass().getPackage().getName());
     }
 
-    public static final String BASE_PATH = "../";
+    public static final String BASE_PATH = "../../";
     public static final String JAVASSIST_JAR = BASE_PATH + "javassist.jar";
     public static final String CLASSES_FOLDER = BASE_PATH + "build/classes";
     public static final String TEST_CLASSES_FOLDER = BASE_PATH + "build/test-classes";

--- a/src/test/javassist/JvstTestRoot.java
+++ b/src/test/javassist/JvstTestRoot.java
@@ -5,10 +5,10 @@ import java.lang.reflect.Method;
 
 public class JvstTestRoot extends TestCase {
     // the directory where all compiled class files are found.
-    public static final String PATH = "../target/test-classes/";
+    public static final String PATH = "../../target/test-classes/";
 
     // the directory where javassist.jar is found.
-    public static final String JAR_PATH = "../";
+    public static final String JAR_PATH = "../../";
 
     ClassPool sloader, dloader;
     Loader cloader;

--- a/src/test/javassist/bytecode/BytecodeTest.java
+++ b/src/test/javassist/bytecode/BytecodeTest.java
@@ -826,12 +826,6 @@ public class BytecodeTest extends TestCase {
         assertEquals("(I)V", cPool2.getUtf8Info(cPool2.getMethodTypeInfo(mtIndex)));
     }
 
-    public static void main(String[] args) {
-        // junit.textui.TestRunner.run(suite());
-        junit.awtui.TestRunner.main(new String[] {
-            "javassist.bytecode.BytecodeTest" });
-    }
-
     public static Test suite() {
         TestSuite suite = new TestSuite("Bytecode Tests");
         suite.addTestSuite(BytecodeTest.class);

--- a/src/test/javassist/compiler/CompTest.java
+++ b/src/test/javassist/compiler/CompTest.java
@@ -113,12 +113,6 @@ public class CompTest extends TestCase {
         assertEquals("(int,char[],String)", s);
     }
 
-    public static void main(String[] args) {
-        // junit.textui.TestRunner.run(suite());
-        junit.awtui.TestRunner.main(new String[] {
-            "javassist.compiler.CompTest" });
-    }
-
     public static Test suite() {
         TestSuite suite = new TestSuite("Compiler Tests");
         suite.addTestSuite(CompTest.class);


### PR DESCRIPTION
This PR collects the following changes:
## Migrated JUnit
Migrated from JUnit ver 3.81 to ver 4.12. also added hamcrest matchers as test dependency for describing asserts.

JUnit 4 is mostly backward compatible with JUnit 3 and can run both version simultaneously.

JUnit dropped the test runners in version 4 since users are running tests through IDEs or build scripts so we had to get rid of the main functions in some tests.

2 tests were dependent on the running order of the tests, JUnit will actually prefer us to not have such dependencies as our tests should be self containing units but they do provide a `@FixMethodOrder` annotation to sort the methods alphabetically which fixed the problem.

All tests succeed on JUnit 4 running with legacy support.


## Squashed maven warnings
There were some maven warnings that were relatively easy to squash. 

* Added configuration for the default build source encoding to be UTF-8.
* Stipulated a version for maven-bundle-plugin 

## Moved test output to build folder

Finally I configured the test outputs, in other words the runtests folder, to be located in the target folder instead of the root project folder (runtests to target/runtests). This way `mvn clean` can clean up these artefacts without any further configuration. 

This change required some tests to have paths tweaked so they may correctly find the new location.
