### PR TITLE
Secure privileged

### DIFF
--- a/src/main/javassist/ClassPool.java
+++ b/src/main/javassist/ClassPool.java
@@ -298,7 +298,7 @@ public class ClassPool {
      * @see #importPackage(String)
      * @since 3.1
      */
-    public Iterator getImportedPackages() {
+    public Iterator<String> getImportedPackages() {
         return importedPackages.iterator();
     }
 

--- a/src/main/javassist/ClassPool.java
+++ b/src/main/javassist/ClassPool.java
@@ -21,19 +21,16 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Method;
 import java.net.URL;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.security.ProtectionDomain;
-import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Iterator;
 
 import javassist.bytecode.ClassFile;
 import javassist.bytecode.Descriptor;
+import javassist.util.proxy.DefinePackageHelper;
 
 /**
  * A container of <code>CtClass</code> objects.
@@ -69,28 +66,8 @@ import javassist.bytecode.Descriptor;
  * @see javassist.CtClass
  * @see javassist.ClassPath
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class ClassPool {
-    private static java.lang.reflect.Method definePackage = null;
-
-    static {
-        if (ClassFile.MAJOR_VERSION < ClassFile.JAVA_9)
-            try {
-                AccessController.doPrivileged(new PrivilegedExceptionAction(){
-                    public Object run() throws Exception{
-                        Class cl = Class.forName("java.lang.ClassLoader");
-                        definePackage = cl.getDeclaredMethod("definePackage",
-                                new Class[] { String.class, String.class, String.class,
-                                        String.class, String.class, String.class,
-                                        String.class, java.net.URL.class });
-                        return null;
-                    }
-                });
-            }
-            catch (PrivilegedActionException pae) {
-                throw new RuntimeException("cannot initialize ClassPool",
-                                           pae.getException());
-            }
-    }
 
     /**
      * Determines the search order.
@@ -1175,43 +1152,7 @@ public class ClassPool {
     public void makePackage(ClassLoader loader, String name)
         throws CannotCompileException
     {
-        if (definePackage == null)
-            throw new CannotCompileException("give the JVM --add-opens");
-
-        Object[] args = new Object[] {
-                name, null, null, null, null, null, null, null };
-        Throwable t;
-        try {
-            makePackage2(definePackage, loader, args);
-            return;
-        }
-        catch (java.lang.reflect.InvocationTargetException e) {
-            t = e.getTargetException();
-            if (t == null)
-                t = e;
-            else if (t instanceof IllegalArgumentException) {
-                // if the package is already defined, an IllegalArgumentException
-                // is thrown.
-                return;
-            }
-        }
-        catch (Exception e) {
-            t = e;
-        }
-
-        throw new CannotCompileException(t);
+        DefinePackageHelper.definePackage(name, loader);
     }
 
-    private static synchronized Object makePackage2(Method method,
-            ClassLoader loader, Object[] args)
-        throws Exception
-    {
-        method.setAccessible(true);
-        try {
-            return method.invoke(loader, args);
-        }
-        finally {
-            method.setAccessible(false);
-        }
-    }
 }

--- a/src/main/javassist/util/proxy/DefineClassHelper.java
+++ b/src/main/javassist/util/proxy/DefineClassHelper.java
@@ -170,7 +170,7 @@ public class DefineClassHelper
 
         };
 
-        public abstract Class<?> defineClass(String name, byte[] b, int off, int len,
+        protected abstract Class<?> defineClass(String name, byte[] b, int off, int len,
                 ClassLoader loader, ProtectionDomain protectionDomain) throws ClassFormatError;
     }
 
@@ -231,4 +231,5 @@ public class DefineClassHelper
         }
     }
 
+    private DefineClassHelper() {}
 }

--- a/src/main/javassist/util/proxy/DefineClassHelper.java
+++ b/src/main/javassist/util/proxy/DefineClassHelper.java
@@ -38,10 +38,10 @@ public class DefineClassHelper
         JAVA_9 {
             final class ReferencedUnsafe
             {
-                private final Object sunMiscUnsafeTheUnsafe;
+                private final SecurityActions.TheUnsafe sunMiscUnsafeTheUnsafe;
                 private final MethodHandle defineClass;
 
-                ReferencedUnsafe(Object usf, MethodHandle meth)
+                ReferencedUnsafe(SecurityActions.TheUnsafe usf, MethodHandle meth)
                 {
                     this.sunMiscUnsafeTheUnsafe = usf;
                     this.defineClass = meth;
@@ -54,7 +54,7 @@ public class DefineClassHelper
                         throw new IllegalAccessError("Access denied for caller.");
                     try {
                         return (Class<?>) defineClass.invokeWithArguments(
-                                sunMiscUnsafeTheUnsafe,
+                                sunMiscUnsafeTheUnsafe.theUnsafe,
                                 name, b, off, len, loader, protectionDomain);
                     } catch (Throwable e) {
                         if (e instanceof RuntimeException) throw (RuntimeException) e;
@@ -72,12 +72,9 @@ public class DefineClassHelper
                         && stack.getCallerClass() != this.getClass())
                     throw new IllegalAccessError("Access denied for caller.");
                 try {
-                    Object usf = SecurityActions.getSunMiscUnsafeAnonymously();
-                    MethodHandle meth = SecurityActions.getMethodHandle(ClassLoader.class, 
-                            "defineClass", new Class[] {
-                                    String.class, byte[].class, int.class, int.class,
-                                    ProtectionDomain.class
-                                });
+                    SecurityActions.TheUnsafe usf = SecurityActions.getSunMiscUnsafeAnonymously();
+                    MethodHandle meth = MethodHandles.lookup()
+                            .unreflect(usf.methods.get("defineClass").get(0));
                     return new ReferencedUnsafe(usf, meth);
                 } catch (Throwable e) {
                     throw new RuntimeException("cannot initialize", e);

--- a/src/main/javassist/util/proxy/DefinePackageHelper.java
+++ b/src/main/javassist/util/proxy/DefinePackageHelper.java
@@ -1,0 +1,179 @@
+/*
+ * Javassist, a Java-bytecode translator toolkit.
+ * Copyright (C) 1999- Shigeru Chiba. All Rights Reserved.
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License.  Alternatively, the contents of this file may be used under
+ * the terms of the GNU Lesser General Public License Version 2.1 or later,
+ * or the Apache License Version 2.0.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ */
+
+package javassist.util.proxy;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.bytecode.ClassFile;
+
+/**
+ * Helper class for invoking {@link ClassLoader#defineClass(String,byte[],int,int)}.
+ *
+ * @since 3.22
+ */
+public class DefinePackageHelper
+{
+            
+    private static enum SecuredPrivileged
+    {
+        JAVA_9 {
+            // definePackage has been discontinued for JAVA 9
+            @Override
+            protected Package definePackage(ClassLoader loader, String name, String specTitle,
+                    String specVersion, String specVendor, String implTitle, String implVersion,
+                    String implVendor, URL sealBase) throws IllegalArgumentException
+            {
+                throw new RuntimeException("define package has been disabled for jigsaw");
+            }
+        },
+        JAVA_7 {
+            private final SecurityActions stack = SecurityActions.stack;
+            private final MethodHandle definePackage = getDefinePackageMethodHandle();
+            private MethodHandle getDefinePackageMethodHandle()
+            {
+                if (stack.getCallerClass() != this.getClass())
+                    throw new IllegalAccessError("Access denied for caller.");
+                try {
+                    return SecurityActions.getMethodHandle(ClassLoader.class, 
+                            "definePackage", new Class[] {
+                                String.class, String.class, String.class, String.class,
+                                String.class, String.class, String.class, URL.class 
+                            });
+                } catch (NoSuchMethodException e) {
+                    throw new RuntimeException("cannot initialize", e);
+                }
+            }
+            
+            @Override
+            protected Package definePackage(ClassLoader loader, String name, String specTitle,
+                    String specVersion, String specVendor, String implTitle, String implVersion,
+                    String implVendor, URL sealBase) throws IllegalArgumentException {
+                if (stack.getCallerClass() != DefinePackageHelper.class)
+                    throw new IllegalAccessError("Access denied for caller.");
+                try {
+                    return (Package) definePackage.invokeWithArguments(loader, name, specTitle,
+                        specVersion, specVendor, implTitle, implVersion, implVendor, sealBase);
+                } catch (Throwable e) {
+                    if (e instanceof IllegalArgumentException) throw (IllegalArgumentException) e;
+                    if (e instanceof RuntimeException) throw (RuntimeException) e;
+                }
+                return null;
+            }
+        },
+        JAVA_OTHER {
+            private final SecurityActions stack = SecurityActions.stack;
+            private final Method definePackage = getDefinePackageMethod();
+            private Method getDefinePackageMethod()
+            {
+                if (stack.getCallerClass() != this.getClass())
+                    throw new IllegalAccessError("Access denied for caller.");
+                try {
+                    return SecurityActions.getDeclaredMethod(ClassLoader.class, 
+                            "definePackage", new Class[] {
+                                String.class, String.class, String.class, String.class,
+                                String.class, String.class, String.class, URL.class 
+                            });
+                } catch (NoSuchMethodException e) {
+                    throw new RuntimeException("cannot initialize", e);
+                }
+            }
+            
+            @Override
+            protected Package definePackage(ClassLoader loader, String name, String specTitle,
+                    String specVersion, String specVendor, String implTitle, String implVersion,
+                    String implVendor, URL sealBase) throws IllegalArgumentException
+            {
+                if (stack.getCallerClass() != DefinePackageHelper.class)
+                    throw new IllegalAccessError("Access denied for caller.");
+                try {
+                    definePackage.setAccessible(true);
+                    return (Package) definePackage.invoke(loader, new Object[] {
+                        name, specTitle, specVersion, specVendor, implTitle,
+                        implVersion, implVendor, sealBase                                
+                    });
+                } catch (Throwable e) {
+                    if (e instanceof InvocationTargetException) {
+                        Throwable t = ((InvocationTargetException) e).getTargetException();
+                        if (t instanceof IllegalArgumentException)
+                            throw (IllegalArgumentException) t;
+                    }
+                    if (e instanceof RuntimeException) throw (RuntimeException) e;
+                }
+                finally {
+                    definePackage.setAccessible(false);
+                }
+                return null;
+            }
+        };
+
+        protected abstract Package definePackage(ClassLoader loader, String name, String specTitle,
+                String specVersion, String specVendor, String implTitle, String implVersion,
+                String implVendor, URL sealBase) throws IllegalArgumentException;
+    }
+
+    private static final SecuredPrivileged privileged = ClassFile.MAJOR_VERSION >= ClassFile.JAVA_9
+            ? SecuredPrivileged.JAVA_9
+            : ClassFile.MAJOR_VERSION >= ClassFile.JAVA_7
+                ? SecuredPrivileged.JAVA_7
+                : SecuredPrivileged.JAVA_OTHER;
+
+
+    /**
+     * Defines a new package.  If the package is already defined, this method
+     * performs nothing.
+     *
+     * <p>You do not necessarily need to
+     * call this method.  If this method is called, then  
+     * <code>getPackage()</code> on the <code>Class</code> object returned 
+     * by <code>toClass()</code> will return a non-null object.</p>
+     *
+     * <p>The jigsaw module introduced by Java 9 has broken this method.
+     * In Java 9 or later, the VM argument
+     * <code>--add-opens java.base/java.lang=ALL-UNNAMED</code>
+     * has to be given to the JVM so that this method can run.
+     * </p>
+     *
+     * @param loader        the class loader passed to <code>toClass()</code> or
+     *                      the default one obtained by <code>getClassLoader()</code>.
+     * @param name          the package name.
+     * @see #getClassLoader()
+     * @see #toClass(CtClass)
+     * @see CtClass#toClass() */
+    public static void definePackage(String className, ClassLoader loader)
+        throws CannotCompileException
+    {
+        try {
+            privileged.definePackage(loader, className, 
+                    null, null, null, null, null, null, null);
+        }
+        catch (IllegalArgumentException e) {
+            // if the package is already defined, an IllegalArgumentException
+            // is thrown.
+            return;
+        }
+        catch (Exception e) {
+            throw new CannotCompileException(e);
+        }
+    }
+    
+    private DefinePackageHelper() {}
+}

--- a/src/main/javassist/util/proxy/SecurityActions.java
+++ b/src/main/javassist/util/proxy/SecurityActions.java
@@ -27,29 +27,31 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 
 class SecurityActions {
-    static Method[] getDeclaredMethods(final Class clazz) {
+    static Method[] getDeclaredMethods(final Class<?> clazz)
+    {
         if (System.getSecurityManager() == null)
             return clazz.getDeclaredMethods();
         else {
-            return (Method[]) AccessController
-                    .doPrivileged(new PrivilegedAction() {
-                        public Object run() {
-                            return clazz.getDeclaredMethods();
-                        }
-                    });
+            return AccessController.doPrivileged(
+                new PrivilegedAction<Method[]>() {
+                    public Method[] run() {
+                        return clazz.getDeclaredMethods();
+                    }
+                });
         }
     }
 
-    static Constructor[] getDeclaredConstructors(final Class clazz) {
+    static Constructor<?>[] getDeclaredConstructors(final Class<?> clazz)
+    {
         if (System.getSecurityManager() == null)
             return clazz.getDeclaredConstructors();
         else {
-            return (Constructor[]) AccessController
-                    .doPrivileged(new PrivilegedAction() {
-                        public Object run() {
-                            return clazz.getDeclaredConstructors();
-                        }
-                    });
+            return AccessController.doPrivileged(
+                new PrivilegedAction<Constructor<?>[]>() {
+                    public Constructor<?>[] run() {
+                        return clazz.getDeclaredConstructors();
+                    }
+                });
         }
     }
 
@@ -83,12 +85,12 @@ class SecurityActions {
             return clazz.getDeclaredMethod(name, types);
         else {
             try {
-                return (Method) AccessController
-                        .doPrivileged(new PrivilegedExceptionAction() {
-                            public Object run() throws Exception {
-                                return clazz.getDeclaredMethod(name, types);
-                            }
-                        });
+                return AccessController.doPrivileged(
+                    new PrivilegedExceptionAction<Method>() {
+                        public Method run() throws Exception {
+                            return clazz.getDeclaredMethod(name, types);
+                        }
+                    });
             }
             catch (PrivilegedActionException e) {
                 if (e.getCause() instanceof NoSuchMethodException)
@@ -99,20 +101,20 @@ class SecurityActions {
         }
     }
 
-    static Constructor getDeclaredConstructor(final Class clazz,
-                                              final Class[] types)
+    static Constructor<?> getDeclaredConstructor(final Class<?> clazz,
+                                              final Class<?>[] types)
         throws NoSuchMethodException
     {
         if (System.getSecurityManager() == null)
             return clazz.getDeclaredConstructor(types);
         else {
             try {
-                return (Constructor) AccessController
-                        .doPrivileged(new PrivilegedExceptionAction() {
-                            public Object run() throws Exception {
-                                return clazz.getDeclaredConstructor(types);
-                            }
-                        });
+                return AccessController.doPrivileged(
+                    new PrivilegedExceptionAction<Constructor<?>>() {
+                        public Constructor<?> run() throws Exception {
+                            return clazz.getDeclaredConstructor(types);
+                        }
+                    });
             }
             catch (PrivilegedActionException e) {
                 if (e.getCause() instanceof NoSuchMethodException)
@@ -124,12 +126,13 @@ class SecurityActions {
     }
 
     static void setAccessible(final AccessibleObject ao,
-                              final boolean accessible) {
+                              final boolean accessible)
+    {
         if (System.getSecurityManager() == null)
             ao.setAccessible(accessible);
         else {
-            AccessController.doPrivileged(new PrivilegedAction() {
-                public Object run() {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                public Void run() {
                     ao.setAccessible(accessible);
                     return null;
                 }
@@ -144,17 +147,17 @@ class SecurityActions {
             fld.set(target, value);
         else {
             try {
-                AccessController.doPrivileged(new PrivilegedExceptionAction() {
-                    public Object run() throws Exception {
-                        fld.set(target, value);
-                        return null;
-                    }
-                });
+                AccessController.doPrivileged(
+                    new PrivilegedExceptionAction<Void>() {
+                        public Void run() throws Exception {
+                            fld.set(target, value);
+                            return null;
+                        }
+                    });
             }
             catch (PrivilegedActionException e) {
                 if (e.getCause() instanceof NoSuchMethodException)
                     throw (IllegalAccessException) e.getCause();
-
                 throw new RuntimeException(e.getCause());
             }
         }

--- a/src/main/javassist/util/proxy/SecurityActions.java
+++ b/src/main/javassist/util/proxy/SecurityActions.java
@@ -162,4 +162,33 @@ class SecurityActions {
             }
         }
     }
+
+    static Object getSunMiscUnsafeAnonymously() throws ClassNotFoundException
+    {
+        try {
+            return AccessController.doPrivileged(
+                new PrivilegedExceptionAction<Object>() { public Object run() throws
+                        ClassNotFoundException, NoSuchFieldException, SecurityException,
+                        IllegalArgumentException, IllegalAccessException {
+                    Class<?> unsafe = Class.forName("sun.misc.Unsafe");
+                    Field theUnsafe = unsafe.getDeclaredField("theUnsafe");
+                    theUnsafe.setAccessible(true);
+                    Object usf = theUnsafe.get(null);
+                    theUnsafe.setAccessible(false);
+                    return usf;
+                }
+            });
+        }
+        catch (PrivilegedActionException e) {
+            if (e.getCause() instanceof ClassNotFoundException)
+                throw (ClassNotFoundException) e.getCause();
+            if (e.getCause() instanceof NoSuchFieldException)
+                throw new ClassNotFoundException("No such instance.", e.getCause());
+            if (e.getCause() instanceof IllegalAccessException
+                    || e.getCause() instanceof IllegalAccessException
+                    || e.getCause() instanceof SecurityException)
+                throw new ClassNotFoundException("Security denied access.", e.getCause());
+            throw new RuntimeException(e.getCause());
+        }
+    }
 }

--- a/src/main/javassist/util/proxy/SecurityActions.java
+++ b/src/main/javassist/util/proxy/SecurityActions.java
@@ -25,8 +25,15 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+class SecurityActions extends SecurityManager
+{
+    public static final SecurityActions stack = new SecurityActions();
+    public Class<?> getCallerClass()
+    {
+        return getClassContext()[2];
+    }
 
-class SecurityActions {
+
     static Method[] getDeclaredMethods(final Class<?> clazz)
     {
         if (System.getSecurityManager() == null)

--- a/src/test/test/javassist/proxy/TestSecuredPrivileged.java
+++ b/src/test/test/javassist/proxy/TestSecuredPrivileged.java
@@ -1,0 +1,281 @@
+package test.javassist.proxy;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.util.proxy.DefineClassHelper;
+
+public class TestSecuredPrivileged {
+
+    public TestSecuredPrivileged() {
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    /**
+     * Test proves that you cannot even access members with
+     * private static and final modifiers. */
+    @Test
+    public void testDefinedHelperPrivilegedFieldVisibility() {
+        try {
+            Field privi = DefineClassHelper.class.getDeclaredField("privileged");
+            assertTrue(Modifier.isStatic(privi.getModifiers()));
+            thrown.expectCause(instanceOf(IllegalAccessException.class));
+            thrown.expectMessage(both(stringContainsInOrder(Arrays.asList("cannot access a member")))
+                    .and(stringContainsInOrder(Arrays.asList("with modifiers \"private static final".split("", 1)))));
+    
+            privi.get(null);
+        } catch(Throwable  t) {
+            throw new RuntimeException(t);
+        }
+    }
+    /**
+     * Test proves that the default enum constant is a class and specifically
+     * auto selected for Java 9. */
+    @Test
+    public void testDefinedHelperPrivilegedField() {
+        try {
+            Field privi = DefineClassHelper.class.getDeclaredField("privileged");
+            assertTrue(Modifier.isStatic(privi.getModifiers()));
+            Constructor<DefineClassHelper> con = DefineClassHelper.class.getDeclaredConstructor();
+            con.setAccessible(true);
+            DefineClassHelper inst = con.newInstance();
+            assertThat(inst, instanceOf(DefineClassHelper.class));
+            privi.setAccessible(true);
+            Object p = privi.get(inst);
+            assertThat(""+p, equalTo("JAVA_9"));
+            assertThat(p.getClass().getName(), endsWith("SecuredPrivileged$1"));
+        } catch(Throwable  t) {
+            throw new RuntimeException(t);
+        }
+    }
+    /**
+     * Test proves that caller class security is enforced and works
+     * as expected. */
+    @Test
+    public void testDefinedHelperPrivilegedFieldMethodAccessDenied() {
+        try {
+            Constructor<DefineClassHelper> con = DefineClassHelper.class.getDeclaredConstructor();
+            con.setAccessible(true);
+            DefineClassHelper inst = con.newInstance();
+            Field privi = DefineClassHelper.class.getDeclaredField("privileged");
+            privi.setAccessible(true);
+            Object priviInst = privi.get(inst);
+            Method defineClass = priviInst.getClass().getDeclaredMethod(
+                    "defineClass", new Class[] {
+                        String.class, byte[].class, int.class, int.class, 
+                        ClassLoader.class, ProtectionDomain.class
+                    });
+        
+            assertThat(defineClass, notNullValue());
+            defineClass.setAccessible(true);
+            assertThat(defineClass.getName(), equalTo("defineClass"));
+            assertTrue(defineClass.canAccess(priviInst));
+            ClassPool cp = ClassPool.getDefault();
+            CtClass c = cp.makeClass("a.b.C");
+            byte[] bc = c.toBytecode();
+
+            thrown.expectCause(instanceOf(IllegalAccessError.class));
+            thrown.expectMessage(equalTo("java.lang.IllegalAccessError: Access denied for caller."));
+
+            @SuppressWarnings("unused")
+            Object res = defineClass.invoke(priviInst, new Object[] {
+                c.getName(), bc, 0, bc.length, new ClassLoader() {},
+                ClassLoader.class.getProtectionDomain()
+            });
+        } catch(InvocationTargetException  t) { 
+            throw new RuntimeException(t.getTargetException());
+        } catch(Throwable  t) { throw new RuntimeException(t); }
+    }
+    /**
+     * Test proves that we do have 3 enum constants in the private static 
+     * inner class. */
+    @Test
+    public void testDefinedHelperEnumClass() {
+        try {
+            Constructor<DefineClassHelper> con = DefineClassHelper.class.getDeclaredConstructor();
+            con.setAccessible(true);
+            assertThat(DefineClassHelper.class.getDeclaredClasses(), arrayWithSize(1));
+            Class<?> secPriv = DefineClassHelper.class.getDeclaredClasses()[0];
+            assertTrue(secPriv.isEnum());
+            assertThat(secPriv.getEnumConstants(), arrayWithSize(3));
+            assertThat(""+secPriv.getEnumConstants()[0], equalTo("JAVA_9"));
+            assertThat(""+secPriv.getEnumConstants()[1], equalTo("JAVA_7"));
+            assertThat(""+secPriv.getEnumConstants()[2], equalTo("JAVA_OTHER"));
+
+        } catch (Throwable t) {t.printStackTrace();}
+
+    }
+    /**
+     * Test proves that you cannot modify private static final reference even 
+     * with setAccessible(true). */
+    @Test
+    public void testDefinedHelperCannotSetPrivileged() {
+        try {
+            Constructor<DefineClassHelper> con = DefineClassHelper.class.getDeclaredConstructor();
+            con.setAccessible(true);
+            DefineClassHelper inst = con.newInstance();
+            Class<?> secPriv = DefineClassHelper.class.getDeclaredClasses()[0];
+            Object J7 = secPriv.getEnumConstants()[1];
+            Field privi = DefineClassHelper.class.getDeclaredField("privileged");
+            privi.setAccessible(true);
+            thrown.expectCause(instanceOf(IllegalAccessException.class));
+            thrown.expectMessage(startsWith("java.lang.IllegalAccessException: Can not set static final"));
+            privi.set(inst, J7);
+
+        } catch (Throwable t) {throw new RuntimeException(t);}
+
+    }
+    /**
+     * Test proves that you can achieve the impossible and modify private
+     * static final class reference without an instance. Now we can Mock
+     * test JDK 6 to 8 functionality  */
+    @Test
+    public void testDefinedHelperSetPrivilegedToJava7() {
+        try {
+            Constructor<DefineClassHelper> con = DefineClassHelper.class.getDeclaredConstructor();
+            con.setAccessible(true);
+            DefineClassHelper inst = con.newInstance();
+            Class<?> secPriv = DefineClassHelper.class.getDeclaredClasses()[0];
+            Object J9 = secPriv.getEnumConstants()[0];
+            Object J7 = secPriv.getEnumConstants()[1];
+            Field privi = DefineClassHelper.class.getDeclaredField("privileged");
+            privi.setAccessible(true);
+            Object privInst = privi.get(inst);
+            Field unsf = privInst.getClass().getDeclaredField("sunMiscUnsafe");
+            unsf.setAccessible(true);
+            Object refu = unsf.get(privInst);
+            Field tuf = refu.getClass().getDeclaredField("sunMiscUnsafeTheUnsafe");
+            tuf.setAccessible(true);
+            Object tu = tuf.get(refu);
+            Method tu_call = tu.getClass().getMethod("call", new Class<?>[] {String.class, Object[].class});
+            tu_call.setAccessible(true);
+            long offset = (Long) tu_call.invoke(tu, new Object[] {"staticFieldOffset",  new Object[] {privi}}); 
+            tu_call.invoke(tu, new Object[] {"putObjectVolatile",  new Object[] {DefineClassHelper.class, offset, J7}});
+
+            Object p = privi.get(inst);
+            assertThat(""+p, equalTo("JAVA_7"));
+            assertThat(p.getClass().getName(), endsWith("SecuredPrivileged$2"));
+
+            tu_call.invoke(tu, new Object[] {"putObjectVolatile",  new Object[] {DefineClassHelper.class, offset, J9}});
+
+        } catch (Throwable t) {t.printStackTrace();}
+
+    }
+    /**
+     * Test proves that Java 7+ MethodHandle defineClass (or DefineClassHelper.toClass)
+     * works as expected. */
+    @Test
+    public void testDefinedHelperJava7ToClass() {
+        try {
+            Constructor<DefineClassHelper> con = DefineClassHelper.class.getDeclaredConstructor();
+            con.setAccessible(true);
+            DefineClassHelper inst = con.newInstance();
+            Class<?> secPriv = DefineClassHelper.class.getDeclaredClasses()[0];
+            Object J9 = secPriv.getEnumConstants()[0];
+            Object J7 = secPriv.getEnumConstants()[1];
+            Field privi = DefineClassHelper.class.getDeclaredField("privileged");
+            privi.setAccessible(true);
+            Object privInst = privi.get(inst);
+            Field unsf = privInst.getClass().getDeclaredField("sunMiscUnsafe");
+            unsf.setAccessible(true);
+            Object refu = unsf.get(privInst);
+            Field tuf = refu.getClass().getDeclaredField("sunMiscUnsafeTheUnsafe");
+            tuf.setAccessible(true);
+            Object tu = tuf.get(refu);
+            Method tu_call = tu.getClass().getMethod("call", new Class<?>[] {String.class, Object[].class});
+            tu_call.setAccessible(true);
+            long offset = (Long) tu_call.invoke(tu, new Object[] {"staticFieldOffset",  new Object[] {privi}}); 
+            tu_call.invoke(tu, new Object[] {"putObjectVolatile",  new Object[] {DefineClassHelper.class, offset, J7}});
+
+            ClassPool cp = ClassPool.getDefault();
+            CtClass c = cp.makeClass("a.b.J7");
+            byte[] bc = c.toBytecode();
+            Class<?> bcCls = DefineClassHelper.toClass("a.b.J7", new ClassLoader() {}, null, bc);
+            assertThat(bcCls.getName(), equalTo("a.b.J7"));
+            assertThat(bcCls.getDeclaredConstructor().newInstance(),
+                    not(equalTo(bcCls.getDeclaredConstructor().newInstance())));
+
+            tu_call.invoke(tu, new Object[] {"putObjectVolatile",  new Object[] {DefineClassHelper.class, offset, J9}});
+            
+        } catch (Throwable t) {t.printStackTrace();}
+
+    }
+    /**
+     * Test proves that Java 6 reflection method defineClass (or DefineClassHelper.toClass)
+     * works as expected. */
+    @Test
+    public void testDefinedHelperJavaOtherToClass() {
+        try {
+            Constructor<DefineClassHelper> con = DefineClassHelper.class.getDeclaredConstructor();
+            con.setAccessible(true);
+            DefineClassHelper inst = con.newInstance();
+            Class<?> secPriv = DefineClassHelper.class.getDeclaredClasses()[0];
+            Object J9 = secPriv.getEnumConstants()[0];
+            Object JO = secPriv.getEnumConstants()[2];
+            Field privi = DefineClassHelper.class.getDeclaredField("privileged");
+            privi.setAccessible(true);
+            Object privInst = privi.get(inst);
+            Field unsf = privInst.getClass().getDeclaredField("sunMiscUnsafe");
+            unsf.setAccessible(true);
+            Object refu = unsf.get(privInst);
+            Field tuf = refu.getClass().getDeclaredField("sunMiscUnsafeTheUnsafe");
+            tuf.setAccessible(true);
+            Object tu = tuf.get(refu);
+            Method tu_call = tu.getClass().getMethod("call", new Class<?>[] {String.class, Object[].class});
+            tu_call.setAccessible(true);
+            long offset = (Long) tu_call.invoke(tu, new Object[] {"staticFieldOffset",  new Object[] {privi}}); 
+            tu_call.invoke(tu, new Object[] {"putObjectVolatile",  new Object[] {DefineClassHelper.class, offset, JO}});
+
+            ClassPool cp = ClassPool.getDefault();
+            CtClass c = cp.makeClass("a.b.JO");
+            byte[] bc = c.toBytecode();
+            Class<?> bcCls = DefineClassHelper.toClass("a.b.JO", new ClassLoader() {}, null, bc);
+            assertThat(bcCls.getName(), equalTo("a.b.JO"));
+            assertThat(bcCls.getDeclaredConstructor().newInstance(),
+                    not(equalTo(bcCls.getDeclaredConstructor().newInstance())));
+
+            tu_call.invoke(tu, new Object[] {"putObjectVolatile",  new Object[] {DefineClassHelper.class, offset, J9}});
+            
+        } catch (Throwable t) {t.printStackTrace();}
+
+    }
+    /**
+     * Test proves that default Java 9 defineClass (or DefineClassHelper.toClass)
+     * works as expected. */
+    @Test
+    public void testDefinedHelperDefaultToClass() {
+        try {
+            ClassPool cp = ClassPool.getDefault();
+            CtClass c = cp.makeClass("a.b.D");
+            byte[] bc = c.toBytecode();
+            Class<?> bcCls = DefineClassHelper.toClass("a.b.D", new ClassLoader() {}, null, bc);
+            assertThat(bcCls.getName(), equalTo("a.b.D"));
+            assertThat(bcCls.getDeclaredConstructor().newInstance(),
+                    not(equalTo(bcCls.getDeclaredConstructor().newInstance())));
+        } catch (Throwable t) {t.printStackTrace();}
+
+    }
+}


### PR DESCRIPTION
Note:
I rebased this branch on top of the junit migration #157 when I wrote the unit tests, so it may appear to have those changes included but this should sort itself out if that PR is committed to master first. If you decide not to merge that PR I could find a way to get this based back to master, something that was not that obvious at first glance or this note could've been avoided. 

 ## Secure Privileged references

This set out to be a noble attempt to reconcile with Oracle and all the restrictions imposed
which is forcing us to go far and beyond to find work arounds to get things done. Lets face it
they have an enormous task still ahead to remove all reference to Sun from Java but perhaps 
we can cut them some slack, they are also improving the product. The least we can do is to
meet them halfway.

After reading this comment by Oracle (or could've been Sun) from the Unsafe header source:

```java
    /**
     * <p>The returned {@code Unsafe} object should be carefully guarded
     * by the caller, since it can be used to read and write data at arbitrary
     * memory addresses.  It must never be passed to untrusted code.
     *
     * <p>Most methods in this class are very low-level, and correspond to a
     * small number of hardware instructions (on typical machines).  Compilers
     * are encouraged to optimize these methods accordingly.
     *
     * <p>Here is a suggested idiom for using unsafe operations:
     *
     * <pre> {@code
     * class MyTrustedClass {
     *   private static final Unsafe unsafe = Unsafe.getUnsafe();
     *   ...
     *   private long myCountAddress = ...;
     *   public int getCount() { return unsafe.getByte(myCountAddress); }
     * }}</pre>
     *
     * (It may assist compilers to make the local variable {@code final}.)
     */
```

As part of the internal API the instruction is aimed to avoid exposing sensitive functionality
to the public API but if we are going to use it ourselves then we can make some effort to not
do the same. It is not just the use of internal API, with `MethodHandles` for instance the 
permissions are checked when they are created and if they are exported then the caller may
use them with the same authority as the creator but permissions aside even just leaking a 
reference should be avoided. 

This ended up being far more effort then originally thought...

## Design
My original plan was to encapsulate the reference within a local private interface accessible only
by the containing class and exposing only the functionality needed ie. the `defineClass` method.

Unfortunately interface static methods was not possible back in 1.6... how quickly we forget. However
this lead to a much cleaner solution which is more particular to our specific use case, wrapping the
privilege in an enum.

An enum can expose abstract methods which its constants can override, this is perfect for choosing functionality based on JDK version capabilities.

```java
public class Foo {
     private static enum JDKVersion {
           JAVA_9 {
                    @Override
                    void doSomething() {
                             // Something only I can do
                    }
            },
            JAVA_OTHER {
                    @Override
                    void doSomething() {
                             // Something only I can do
                    }
            }
            abstract void doSomething();
     }
 
    private static final JDKVersion chosen = (VERSION >= JAVA_9)
             ? JDKVersion.JAVA_9
             : JDKVersion.JAVA_OTHER;

     public void doIt() {
           this.chosen.doSomething();
     }
}
```

Now we don't have any reference to the definition or the implementation to expose but if we are 
serious about securing this functionality we need to verify that the caller is our enclosing class 
only or we throw an exception.

## Get caller class 
Java 9 introduces `StackWalker` and removes the previously available `Reflection.getCallerClass()`.

Java 8 sun.reflect.Reflection excerpt:
```java
    /** Returns the class of the caller of the method calling this method,
        ignoring frames associated with java.lang.reflect.Method.invoke()
        and its implementation. */
    @CallerSensitive
    public static native Class<?> getCallerClass();

    /**
     * @deprecated This method will be removed in JDK 9.
     * This method is a private JDK API and retained temporarily for
     * existing code to run until a replacement API is defined.
     */
    @Deprecated
    public static native Class<?> getCallerClass(int depth);
```
Java 9 sun.reflect.Reflection version:
```java
    /**
     * @deprecated This method is an internal API and will be removed.
     * Use {@link StackWalker} to walk the stack and obtain the caller class
     * with {@link StackWalker.StackFrame#getDeclaringClass} instead.
     */
    @Deprecated(forRemoval=true)
    public static Class<?> getCallerClass(int depth);
```
So they didn't remove the one they promised instead they removed the method that was not
deprecated. This might have been unintentional, the no argument version was widely used in 
the core API and removing the method would be the easiest way to apply the new functionality
so perhaps they just forgot to put it back. 

Either way this leaves us with a predicament, if we want to build with Java 9 we will need to implement the deprecated version for the older JDKs and that seems wrong, so we need to find another way to 
to get the caller class. One way is to throw a new exception which generates a call stack trace
but this adds a huge overhead which is not plausible. 

Luckily there is another way to gain access to the caller stack through `SecurityManager` which
exposes a native implementation to it's members via `getClassContext`.

Java 6 java.lang.SecurityManager excerpt:
```java
    /**
     * Returns the current execution stack as an array of classes.
     * <p>
     * The length of the array is the number of methods on the execution
     * stack. The element at index <code>0</code> is the class of the
     * currently executing method, the element at index <code>1</code> is
     * the class of that method's caller, and so on.
     *
     * @return  the execution stack.
     */
    protected native Class[] getClassContext();
```

## Ensure privileged

We know we are taking privileges but we are trying not to do anything underhanded so lets ensure we
invoke these privileges under `AccessController` to give the security policy a chance to decide 
whether or not to allow us access and then treat the code accordingly. 

This includes accessing members not generally visible through reflection as well as gaining access to internal proprietary API.

## Access sun.misc.Unsafe Anonymously 

It still upsets the compiler to give us a reference to the internal proprietary API so lets keep these
anonymous so as not to raise any unnecessary red flags and warnings. We can expose what we need
without importing the `sun.misc` package by keeping reference to the Unsafe as a plain Object and in so doing the allow the compiler to finish it's chores without upset.

## Method handles

With method handles the access is tested when the method handle is created instead of the having
to manipulate the privilege on every invoke as is the case with reflection method. This PR produces MethodHandles for Java 7 and above while reverting to reflection methods for the Java 6 support.

Also refactored the `definePackage` implementation to reflect that of `defineClass`, which allowed
for cleaning out the crud from `ClassPool`.

## Illegal Access

Now there's a new kid on the block which is ill informed and a real tattletale of note, allow me introduce
 you to `jdk.internal.module.IllegalAccessLogger` who has been tasked to monitor our actions and spew warnings out to `System.err` if it finds anything suspicious going on. You should have a look at what it has to say...

```
WARNING: Illegal reflective access...
WARNING: An illegal reflective access operation has occurred
WARNING: All illegal access operations will be denied in a future release
```

At first I thought oh crap, the Unsafe again but as it turns out it is completely unaffected by any
actions performed there and it has absolutely no problem with us using unsafe. What it throws a
fuss over is the use of `setAccessible`. What do you mean **illegal access**, my permissions were checked and I was granted access so there is absolutely nothing **"illegal"** about it in any way!!

If that is not the worst of it all, it continues to say:
```
WARNING: Please consider reporting this to the maintainers of...
```
Now the warnings are one thing but obviously these developers are so nicely cushioned against their
support call centre whom by the way are closed to the general public that they have no regard for the
rest of us who are simply trying to provide functionality requested by users without expecting
compensation for it and without the luxury of a call centre to handle these requests.

Sure they don't want us to use reflection and they gather that user pressure will accomplish that but if we had any other choice we wouldn't need to use reflection. They wouldn't need to monitor and complain about it either as they could just simply remove the functionality as they did with 
`getCallerClass`.

What they don't need to do is upsetting the users and to rally them against us!

Since using the Unsafe is not **"illegal"** then using it to cut out this guy's tongue is justifiable. It can certainly not be allowed to continue to spread discourse. We already have a reference to the Unsafe
but chose to keep it anonymous. If we are going to use more than one method then wrapping
it up to expose functionality is the logical next step. 

Only did the bare minimum for what were require which includes a method cache and a invoke method
helper which takes the method name and VarArgs for the parameters. If any overloaded methods exist they are not lost but the implementation currently only assumes the 1st method when needed.

## Test proofs

Unit tests are provided to proof that there is no reference to the privileged content, that `private static final` attributes are not accessible as expected and that the caller restriction is enforced.

Then proceeds to mock test the 3 different implementations through the public access toClass disregarding any imposed restrictions previously proven.

## Conclusion

Oracle is going to do what it feels like and obviously have no regard for projects adding support and
functionality so there is no point trying to please them. It is up to us to make it work as we need.

The encapsulation works as intended and with the additional security effectively prevents exposure. Aside from the caller checks all the visibility restrictions are easily overcome through reflection, albeit requiring slightly more effort than simply accessing a member field. There is no significant 
performance impact as all tests seem to complete within the some timespan with or without the patch but whether the added security is required remains debatable. If this needs to be removed from the patch I will gladly do so.

However I do think the clean approach for specifying functionality based on JDK capabilities provided by the enum implementation is an improvement. There should also be a performance increase for using method handles when doing multiple invokes using the same referenced handle.

Avoiding compiler and runtime warnings provided by the patch will go a long way to appeasing users
who need no excuse to log an issue or complain.

I have some more time over the weekend to work on this if you require any changes. 

nJoy!
