### PR TITLE
Unit Test: CtField.make referencing 'this'.

### DIFF
--- a/src/test/javassist/JvstTest.java
+++ b/src/test/javassist/JvstTest.java
@@ -103,6 +103,10 @@ public class JvstTest extends JvstTestRoot {
         cc.addField(f2);
         CtField f3 = CtField.make("public int f3;", cc);
         cc.addField(f3);
+        CtField f4 = CtField.make("public int f4 = this.f2 + 3;", cc);
+        cc.addField(f4);
+        CtField fi = CtField.make("public test1.FieldInit.FI fi = new test1.FieldInit.FI(this);", cc);
+        cc.addField(fi);
         testFieldInitHash = f1.hashCode();
         cc.writeFile();
         Object obj = make(cc.getName());
@@ -112,6 +116,10 @@ public class JvstTest extends JvstTestRoot {
         assertEquals(3, value2);
         int value3 = obj.getClass().getField("f3").getInt(obj);
         assertEquals(0, value3);
+        int value4 = obj.getClass().getField("f4").getInt(obj);
+        assertEquals(6, value4);
+        Object obfi = obj.getClass().getField("fi").get(obj);
+        assertTrue(obfi.getClass().getField("fi").get(obfi) == obj);
     }
 
     /* test CodeIterator.insertExGap().

--- a/src/test/test1/FieldInit.java
+++ b/src/test/test1/FieldInit.java
@@ -14,4 +14,11 @@ public class FieldInit {
 	    --loop;
 	} while (loop > 0);
     }
+
+    public static class FI {
+        public FieldInit fi;
+        public FI(FieldInit fi) {
+            this.fi = fi;
+        }
+    }
 }


### PR DESCRIPTION
Note: still depends on on PR #157

Couldn't find any unit tests that actually tested CtField.make with `this` referencing, so added it. 

As per question raised in #161 passing `this` reference for CtField value new object instance.

Also added assert for testing referencing `this` for newly added field.