### PR TITLE
Fix for #152 inner class modifiers.

### DIFF
--- a/src/main/javassist/CtClassType.java
+++ b/src/main/javassist/CtClassType.java
@@ -446,9 +446,19 @@ class CtClassType extends CtClass {
         int acc = cf.getAccessFlags();
         acc = AccessFlag.clear(acc, AccessFlag.SUPER);
         int inner = cf.getInnerAccessFlags();
-        if (inner != -1 && (inner & AccessFlag.STATIC) != 0)
-            acc |= AccessFlag.STATIC;
-
+        if (inner != -1) {
+            if ((inner & AccessFlag.STATIC) != 0)
+                acc |= AccessFlag.STATIC;
+            if ((inner & AccessFlag.PUBLIC) != 0)
+                acc |= AccessFlag.PUBLIC;
+            else {
+                acc &= ~AccessFlag.PUBLIC; //clear PUBLIC
+                if ((inner & AccessFlag.PROTECTED) != 0)
+                    acc |= AccessFlag.PROTECTED;
+                else if ((inner & AccessFlag.PRIVATE) != 0)
+                    acc |= AccessFlag.PRIVATE;
+            }
+        }
         return AccessFlag.toModifier(acc);
     }
 

--- a/src/test/javassist/JvstTest5.java
+++ b/src/test/javassist/JvstTest5.java
@@ -344,6 +344,52 @@ public class JvstTest5 extends JvstTestRoot {
         assertEquals(Modifier.PUBLIC, ica4.accessFlags(i5));
     }
 
+    public void testInnerClassModifiers2() throws Exception {
+        CtClass cc = sloader.get("test5.InnerModifier2$Protected");
+        Class<?> ccc = Class.forName("test5.InnerModifier2$Protected");
+        assertEquals(cc.getModifiers(), ccc.getModifiers());
+        assertTrue(Modifier.isProtected(cc.getModifiers()));
+
+        cc = sloader.get("test5.InnerModifier2$Public");
+        ccc = Class.forName("test5.InnerModifier2$Public");
+        assertEquals(cc.getModifiers(), ccc.getModifiers());
+        assertTrue(Modifier.isPublic(cc.getModifiers()));
+
+        cc = sloader.get("test5.InnerModifier2$Private");
+        ccc = Class.forName("test5.InnerModifier2$Private");
+        assertEquals(cc.getModifiers(), ccc.getModifiers());
+        assertTrue(Modifier.isPrivate(cc.getModifiers()));
+
+        cc = sloader.get("test5.InnerModifier2$Package");
+        ccc = Class.forName("test5.InnerModifier2$Package");
+        assertEquals(cc.getModifiers(), ccc.getModifiers());
+        assertTrue(Modifier.isPackage(cc.getModifiers()));
+
+        cc = sloader.get("test5.InnerModifier2$ProtectedStatic");
+        ccc = Class.forName("test5.InnerModifier2$ProtectedStatic");
+        assertEquals(cc.getModifiers(), ccc.getModifiers());
+        assertTrue(Modifier.isProtected(cc.getModifiers()));
+        assertTrue(Modifier.isStatic(cc.getModifiers()));
+
+        cc = sloader.get("test5.InnerModifier2$PublicStatic");
+        ccc = Class.forName("test5.InnerModifier2$PublicStatic");
+        assertEquals(cc.getModifiers(), ccc.getModifiers());
+        assertTrue(Modifier.isPublic(cc.getModifiers()));
+        assertTrue(Modifier.isStatic(cc.getModifiers()));
+
+        cc = sloader.get("test5.InnerModifier2$PrivateStatic");
+        ccc = Class.forName("test5.InnerModifier2$PrivateStatic");
+        assertEquals(cc.getModifiers(), ccc.getModifiers());
+        assertTrue(Modifier.isPrivate(cc.getModifiers()));
+        assertTrue(Modifier.isStatic(cc.getModifiers()));
+
+        cc = sloader.get("test5.InnerModifier2$PackageStatic");
+        ccc = Class.forName("test5.InnerModifier2$PackageStatic");
+        assertEquals(cc.getModifiers(), ccc.getModifiers());
+        assertTrue(Modifier.isPackage(cc.getModifiers()));
+        assertTrue(Modifier.isStatic(cc.getModifiers()));
+    }
+
     private InnerClassesAttribute getInnerClassAttr(CtClass cc) {
         return (InnerClassesAttribute)cc.getClassFile2().getAttribute(InnerClassesAttribute.tag);
     }

--- a/src/test/test5/InnerModifier2.java
+++ b/src/test/test5/InnerModifier2.java
@@ -1,0 +1,13 @@
+package test5;
+
+@SuppressWarnings("unused")
+public class InnerModifier2 {
+    public class Public {}
+    protected class Protected {}
+    private class Private {}
+    class Package {}
+    public static class PublicStatic {}
+    protected static class ProtectedStatic {}
+    private static class PrivateStatic {}
+    static class PackageStatic {}
+}


### PR DESCRIPTION
Note: also depends on on PR #157 

Applied fix for #152 "Wrong modifiers returned for nested classes" as suggested by @pietrobraione.
Includes unit tests for all access modifiers and static.

