### PR TITLE
Custom URL stream handler in ByteArrayClassPath

### DIFF
--- a/src/main/javassist/ByteArrayClassPath.java
+++ b/src/main/javassist/ByteArrayClassPath.java
@@ -17,9 +17,12 @@
 package javassist;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 
 /**
  * A <code>ByteArrayClassPath</code> contains bytes that is served as
@@ -86,12 +89,34 @@ public class ByteArrayClassPath implements ClassPath {
         if(this.classname.equals(classname)) {
             String cname = classname.replace('.', '/') + ".class";
             try {
-                // return new File(cname).toURL();
-                return new URL("file:/ByteArrayClassPath/" + cname);
+                return new URL(null, "file:/ByteArrayClassPath/" + cname, new BytecodeURLStreamHandler());
             }
             catch (MalformedURLException e) {}
         }
 
         return null;
+    }
+
+    private class BytecodeURLStreamHandler extends URLStreamHandler {
+        protected URLConnection openConnection(final URL u) {
+            return new BytecodeURLConnection(u);
+        }
+    }
+
+    private class BytecodeURLConnection extends URLConnection {
+        protected BytecodeURLConnection(URL url) {
+            super(url);
+        }
+
+        public void connect() throws IOException {
+        }
+
+        public InputStream getInputStream() throws IOException {
+            return new ByteArrayInputStream(classfile);
+        }
+
+        public int getContentLength() {
+            return classfile.length;
+        }
     }
 }


### PR DESCRIPTION
Otherwise a normal streamhandler lookup is made and if javassist is used early on server startup protses this can lead to a deadlock on rare cases on WebSpheare.
For example. A new StreamHandlerFactory is registered but not jet fully initialized. Now javassist is used at the same time but form another thread and it will be the first one to invoke the new StreamHandlerFactory and now it can deadlock with the other thread:

Snipets from my deadlock:
3XMTHREADINFO      "main" J9VMThread:0x000000000175EC00, omrthread_t:0x00007F4120008100, java/lang/Thread:0x00000000624290B8, state:B, prio=5
3XMTHREADBLOCK     Blocked on: org/osgi/util/tracker/ServiceTracker$Tracked@0x00000000627F0A90 Owned by: "other-thread" (J9VMThread:0x0000000001B26300, java/lang/Thread:0x00000000629F1458)
3XMHEAPALLOC             Heap bytes allocated since last GC cycle=0 (0x0)
3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at org/osgi/util/tracker/ServiceTracker.getServiceReferences(ServiceTracker.java:525)
4XESTACKTRACE                at org/eclipse/osgi/framework/internal/protocol/StreamHandlerFactory.createInternalURLStreamHandler(StreamHandlerFactory.java:162)
4XESTACKTRACE                at org/eclipse/osgi/framework/internal/protocol/StreamHandlerFactory.createURLStreamHandler(StreamHandlerFactory.java:118)
4XESTACKTRACE                at java/net/URL.getURLStreamHandler(URL.java:1154)
4XESTACKTRACE                at java/net/URL.<init>(URL.java:611(Compiled Code))
4XESTACKTRACE                at java/net/URL.<init>(URL.java:502(Compiled Code))
4XESTACKTRACE                at java/net/URL.<init>(URL.java:451)
4XESTACKTRACE                at javassist/ByteArrayClassPath.find(JRebel:92)
...
4XESTACKTRACE                at java/lang/ClassLoader.loadClassHelper(ClassLoader.java:924(Compiled Code))
5XESTACKTRACE                   (entered lock: org/eclipse/core/launcher/Main$StartupClassLoader@0x0000000062F3AA88, entry count: 1)

3XMTHREADINFO      "other-thread" J9VMThread:0x0000000001B26300, omrthread_t:0x00007F4120A5D060, java/lang/Thread:0x00000000629F1458, state:B, prio=5
3XMTHREADBLOCK     Blocked on: org/eclipse/core/launcher/Main$StartupClassLoader@0x0000000062F3AA88 Owned by: "main" (J9VMThread:0x000000000175EC00, java/lang/Thread:0x00000000624290B8)
3XMHEAPALLOC             Heap bytes allocated since last GC cycle=0 (0x0)
3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at org/osgi/util/tracker/AbstractTracked.size(AbstractTracked.java:356)
4XESTACKTRACE                at org/osgi/util/tracker/ServiceTracker.getServiceReferences(ServiceTracker.java:526)
5XESTACKTRACE                   (entered lock: org/osgi/util/tracker/ServiceTracker$Tracked@0x00000000627F0A90, entry count: 1)
4XESTACKTRACE                at org/eclipse/osgi/framework/internal/protocol/StreamHandlerFactory.createInternalURLStreamHandler(StreamHandlerFactory.java:162)
4XESTACKTRACE                at org/eclipse/osgi/framework/internal/protocol/StreamHandlerFactory.createURLStreamHandler(StreamHandlerFactory.java:118)
4XESTACKTRACE                at java/net/URL.getURLStreamHandler(URL.java:1154)
4XESTACKTRACE                at java/net/URL.<init>(URL.java:611(Compiled Code))
4XESTACKTRACE                at java/net/URL.<init>(URL.java:502(Compiled Code))
4XESTACKTRACE                at java/net/URL.<init>(URL.java:451)
4XESTACKTRACE                at java/net/URI.toURL(URI.java:1100)
4XESTACKTRACE                at com/ibm/jsse2/av.a(av.java:92)
4XESTACKTRACE                at com/ibm/jsse2/av.engineInit(av.java:7)
4XESTACKTRACE                at javax/net/ssl/TrustManagerFactory.init(TrustManagerFactory.java:25)