### PR TITLE
Add support for Java 11 NestHost and NestMembers attributes

### DIFF
--- a/src/main/javassist/bytecode/AttributeInfo.java
+++ b/src/main/javassist/bytecode/AttributeInfo.java
@@ -108,6 +108,10 @@ public class AttributeInfo {
             /* Note that the names of Annotations attributes begin with 'R'. */
             if (nameStr.equals(MethodParametersAttribute.tag))
                 return new MethodParametersAttribute(cp, name, in);
+            else if (nameStr.equals(NestHostAttribute.tag))
+                return new NestHostAttribute(cp, name, in);
+            else if (nameStr.equals(NestMembersAttribute.tag))
+                return new NestMembersAttribute(cp, name, in);
             else if (nameStr.equals(AnnotationsAttribute.visibleTag)
                      || nameStr.equals(AnnotationsAttribute.invisibleTag))
                 // RuntimeVisibleAnnotations or RuntimeInvisibleAnnotations

--- a/src/main/javassist/bytecode/NestHostAttribute.java
+++ b/src/main/javassist/bytecode/NestHostAttribute.java
@@ -1,0 +1,39 @@
+package javassist.bytecode;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * <code>NestHost_attribute</code>.
+ */
+public class NestHostAttribute extends AttributeInfo {
+    /**
+     * The name of this attribute <code>"NestHost"</code>.
+     */
+    public static final String tag = "NestHost";
+
+    NestHostAttribute(ConstPool cp, int n, DataInputStream in) throws IOException {
+        super(cp, n, in);
+    }
+
+    private NestHostAttribute(ConstPool cp, int hostIndex) {
+        super(cp, tag, new byte[2]);
+        ByteArray.write16bit(hostIndex, get(), 0);
+    }
+
+    /**
+     * Makes a copy.  Class names are replaced according to the
+     * given <code>Map</code> object.
+     *
+     * @param newCp     the constant pool table used by the new copy.
+     * @param classnames        pairs of replaced and substituted
+     *                          class names.
+     */
+    @Override
+    public AttributeInfo copy(ConstPool newCp, Map<String, String> classnames) {
+        int hostIndex = ByteArray.readU16bit(get(), 0);
+        int newHostIndex = getConstPool().copy(hostIndex, newCp, classnames);
+        return new NestHostAttribute(newCp, newHostIndex);
+    }
+}

--- a/src/main/javassist/bytecode/NestMembersAttribute.java
+++ b/src/main/javassist/bytecode/NestMembersAttribute.java
@@ -1,0 +1,49 @@
+package javassist.bytecode;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * <code>NestMembers_attribute</code>.
+ */
+public class NestMembersAttribute extends AttributeInfo {
+    /**
+     * The name of this attribute <code>"NestMembers"</code>.
+     */
+    public static final String tag = "NestMembers";
+
+    NestMembersAttribute(ConstPool cp, int n, DataInputStream in) throws IOException {
+        super(cp, n, in);
+    }
+
+    private NestMembersAttribute(ConstPool cp, byte[] info) {
+        super(cp, tag, info);
+    }
+
+    /**
+     * Makes a copy.  Class names are replaced according to the
+     * given <code>Map</code> object.
+     *
+     * @param newCp     the constant pool table used by the new copy.
+     * @param classnames        pairs of replaced and substituted
+     *                          class names.
+     */
+    @Override
+    public AttributeInfo copy(ConstPool newCp, Map<String, String> classnames) {
+        byte[] src = get();
+        byte[] dest = new byte[src.length];
+        ConstPool cp = getConstPool();
+
+        int n = ByteArray.readU16bit(src, 0);
+        ByteArray.write16bit(n, dest, 0);
+
+        for (int i = 0, j = 2; i < n; ++i, j += 2) {
+            int index = ByteArray.readU16bit(src, j);
+            int newIndex = cp.copy(index, newCp, classnames);
+            ByteArray.write16bit(newIndex, dest, j);
+        }
+
+        return new NestMembersAttribute(newCp, dest);
+    }
+}


### PR DESCRIPTION
This change adds basic support for the new `NestHost` and `NestMembers` class file attributes (JEP-181).

The important part are the copy methods. Without those, transforming a Java 11 class that contains either of the two attributes in a way that causes the constant pool to be rebuilt will lead to invalid constant pool indices inside these attributes.