### PR TITLE
Re-enable JDK7 runtime compatibility for Javassist 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <testSource>11</testSource>
           <testTarget>11</testTarget>
           <testCompilerArgument>-parameters</testCompilerArgument>


### PR DESCRIPTION
Re-enable `JDK7` runtime compatibility for Javassist 3.x builds (until source changes preclude it).

`pom.xml` changes:
- lower compile source/target to 1.7 (from 1.8, introduced with `Javassist 3.24.0`)

This PR should resolve https://github.com/jboss-javassist/javassist/issues/229