### PR TITLE
Add back FactoryHelper.toClass(ClassFile cf, ClassLoader loader, Prot…

### DIFF
--- a/src/main/javassist/util/proxy/FactoryHelper.java
+++ b/src/main/javassist/util/proxy/FactoryHelper.java
@@ -116,6 +116,24 @@ public class FactoryHelper {
     /**
      * Loads a class file by a given class loader.
      *
+     * @param loader        The class loader.  It can be null if {@code neighbor}
+     *                      is not null.
+     *
+     * @param domain        if it is null, a default domain is used.
+     * @since 3.3
+     *
+     * @see #toClass(ClassFile,Class,ClassLoader,ProtectionDomain)
+     * @deprecated
+     */
+    public static Class<?> toClass(ClassFile cf, ClassLoader loader, ProtectionDomain domain)
+        throws CannotCompileException
+    {
+        return toClass(cf, null, loader, domain);
+    }
+
+    /**
+     * Loads a class file by a given class loader.
+     *
      * @param neighbor      a class belonging to the same package that
      *                      the loaded class belongs to.
      *                      It can be null.


### PR DESCRIPTION
…ectionDomain domain) for backward compatibility in minor release.
https://github.com/jboss-javassist/javassist/commit/6320bc4e14350af392b285b1b1ea312673625b21#diff-ddec044ab147cbae4c1402c4be2aacacR127 changed the FactoryHelper.toClass method signature. This breaks Hibernate use.

I see there is no major version 4 plan yet. But, can we simply add previous deprecated method signature back with neighbor to **null** ? 