### PR TITLE
Generics params support renaming

### DIFF
--- a/src/main/javassist/bytecode/ConstPool.java
+++ b/src/main/javassist/bytecode/ConstPool.java
@@ -2158,6 +2158,36 @@ class Utf8Info extends ConstInfo
     public int getTag() { return tag; }
 
     @Override
+    public void renameClass(ConstPool cp, String oldName, String newName,
+                            Map<ConstInfo, ConstInfo> cache)
+    {
+        String desc = string;
+        String desc2 = Descriptor.renameGenerics(desc, oldName, newName);
+        if (!desc.equals(desc2)) {
+            string = desc2;
+            if (cache != null) {
+                cache.remove(this);
+                cache.put(this, this);
+            }
+        }
+    }
+
+    @Override
+    public void renameClass(ConstPool cp, Map<String, String> map,
+                            Map<ConstInfo, ConstInfo> cache)
+    {
+        String desc = string;
+        String desc2 = Descriptor.renameGenerics(desc, map);
+        if (!desc.equals(desc2)) {
+            string = desc2;
+            if (cache != null) {
+                cache.remove(this);
+                cache.put(this, this);
+            }
+        }
+    }
+
+    @Override
     public int copy(ConstPool src, ConstPool dest,
             Map<String,String> map)
     {

--- a/src/main/javassist/bytecode/Descriptor.java
+++ b/src/main/javassist/bytecode/Descriptor.java
@@ -16,6 +16,7 @@
 
 package javassist.bytecode;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javassist.ClassPool;
@@ -221,6 +222,84 @@ public class Descriptor {
                 newdesc.append(name2);
                 newdesc.append(';');
                 head = i;
+            }
+        }
+
+        if (head == 0)
+            return desc;
+        int len = desc.length();
+        if (head < len)
+            newdesc.append(desc.substring(head, len));
+
+        return newdesc.toString();
+    }
+
+    /**
+     * Substitutes a class name
+     * in the given descriptor string.
+     *
+     * @param desc    descriptor string
+     * @param oldname replaced JVM class name
+     * @param newname substituted JVM class name
+     *
+     * @see Descriptor#toJvmName(String)
+     */
+    public static String renameGenerics(String desc, String oldname, String newname) {
+        if (!desc.contains(oldname))
+            return desc;
+
+        Map<String, String> map = new HashMap<>();
+        map.put(oldname, newname);
+        return renameGenerics(desc, map);
+    }
+
+    /**
+     * Substitutes class names in the given descriptor string
+     * according to the given <code>map</code>
+     *
+     * @param map a map between replaced and substituted
+     *            JVM class name.
+     * @see Descriptor#toJvmName(String)
+     */
+    public static String renameGenerics(String desc, Map<String, String> map) {
+        if (map == null)
+            return desc;
+
+        StringBuffer newdesc = new StringBuffer();
+        int head = 0;
+        int i = 0;
+        for (;;) {
+            int j = desc.indexOf('L', i);
+            if (j < 0)
+                break;
+
+            int k = desc.indexOf(';', j);
+            int l = desc.indexOf('<', j);
+            if (k < 0)
+                break;
+
+            if (l < 0 || k < l) {
+                i = k + 1;
+                String name = desc.substring(j + 1, k);
+                String name2 = map.get(name);
+                if (name2 != null) {
+                    newdesc.append(desc.substring(head, j));
+                    newdesc.append('L');
+                    newdesc.append(name2);
+                    newdesc.append(';');
+                    head = i;
+                }
+            } else {
+                i = l + 1;
+                String name = desc.substring(j + 1, l);
+                String name2 = map.get(name);
+                if (name2 != null) {
+                    newdesc.append(desc.substring(head, j));
+                    newdesc.append('L');
+                    newdesc.append(name2);
+                    newdesc.append('<');
+                    head = i;
+                }
             }
         }
 


### PR DESCRIPTION
In the process of using javassist, I found a problem：

I change the class name through the method of `replaceClassName`. And generate class files through the method of `writeFile`.
However, some imports could not be successfully changed.

Ultimately, I found that it was caused by generics, and the problem was fixed by this pr.