### PR TITLE
fixes a bug of ClassFile#renameClass(), some imports could not be successfully renamed.

### DIFF
--- a/src/main/javassist/bytecode/AnnotationDefaultAttribute.java
+++ b/src/main/javassist/bytecode/AnnotationDefaultAttribute.java
@@ -117,6 +117,28 @@ public class AnnotationDefaultAttribute extends AttributeInfo {
         }
     }
 
+    @Override
+    void renameClass(String oldname, String newname) {
+        try {
+            MemberValue defaultValue = getDefaultValue();
+            defaultValue.renameClass(oldname, newname);
+            setDefaultValue(defaultValue);
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    @Override
+    void renameClass(Map<String, String> classnames) {
+        try {
+            MemberValue defaultValue = getDefaultValue();
+            defaultValue.renameClass(classnames);
+            setDefaultValue(defaultValue);
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
     /**
      * Obtains the default value represented by this attribute.
      */

--- a/src/main/javassist/bytecode/AttributeInfo.java
+++ b/src/main/javassist/bytecode/AttributeInfo.java
@@ -254,7 +254,7 @@ public class AttributeInfo {
     /* The following two methods are used to implement
      * ClassFile.renameClass().
      * Only CodeAttribute, LocalVariableAttribute,
-     * AnnotationsAttribute, and SignatureAttribute
+     * AnnotationDefaultAttribute, AnnotationsAttribute, and SignatureAttribute
      * override these methods.
      */
     void renameClass(String oldname, String newname) {}

--- a/src/main/javassist/bytecode/SignatureAttribute.java
+++ b/src/main/javassist/bytecode/SignatureAttribute.java
@@ -121,29 +121,29 @@ public class SignatureAttribute extends AttributeInfo {
             if (j < 0)
                 break;
 
-            StringBuilder nameBuf = new StringBuilder();
-            int k = j;
-            char c;
-            try {
-                while ((c = desc.charAt(++k)) != ';') {
-                    nameBuf.append(c);
-                    if (c == '<') {
-                        while ((c = desc.charAt(++k)) != '>')
-                            nameBuf.append(c);
+            int k = desc.indexOf(';', j);
+            if (k < 0)
+                break;
 
-                        nameBuf.append(c);
-                    }
-                }
+            int l = desc.indexOf('<', j);
+            int classEndIndex;
+            char classEndChar;
+            if (l < 0 || k < l) {
+                classEndIndex = k;
+                classEndChar = ';';
+            } else {
+                classEndIndex = l;
+                classEndChar = '<';
             }
-            catch (IndexOutOfBoundsException e) { break; }
-            i = k + 1;
-            String name = nameBuf.toString();
+            i = classEndIndex + 1;
+
+            String name = desc.substring(j + 1, classEndIndex);
             String name2 = map.get(name);
             if (name2 != null) {
                 newdesc.append(desc.substring(head, j));
                 newdesc.append('L');
                 newdesc.append(name2);
-                newdesc.append(c);
+                newdesc.append(classEndChar);
                 head = i;
             }
         }

--- a/src/main/javassist/bytecode/annotation/ArrayMemberValue.java
+++ b/src/main/javassist/bytecode/annotation/ArrayMemberValue.java
@@ -18,6 +18,7 @@ package javassist.bytecode.annotation;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import javassist.ClassPool;
 import javassist.bytecode.ConstPool;
@@ -85,6 +86,30 @@ public class ArrayMemberValue extends MemberValue {
 
         Object a = Array.newInstance(type.getType(cl), 0);
         return a.getClass();
+    }
+
+    @Override
+    public void renameClass(String oldname, String newname) {
+        if (type != null) {
+            type.renameClass(oldname, newname);
+        }
+        if (values != null) {
+            for (MemberValue value : values) {
+                value.renameClass(oldname, newname);
+            }
+        }
+    }
+
+    @Override
+    public void renameClass(Map<String, String> classnames) {
+        if (type != null) {
+            type.renameClass(classnames);
+        }
+        if (values != null) {
+            for (MemberValue value : values) {
+                value.renameClass(classnames);
+            }
+        }
     }
 
     /**

--- a/src/main/javassist/bytecode/annotation/ClassMemberValue.java
+++ b/src/main/javassist/bytecode/annotation/ClassMemberValue.java
@@ -18,6 +18,7 @@ package javassist.bytecode.annotation;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import javassist.ClassPool;
 import javassist.bytecode.BadBytecode;
@@ -93,6 +94,20 @@ public class ClassMemberValue extends MemberValue {
     @Override
     Class<?> getType(ClassLoader cl) throws ClassNotFoundException {
         return loadClass(cl, "java.lang.Class");
+    }
+
+    @Override
+    public void renameClass(String oldname, String newname) {
+        String value = cp.getUtf8Info(valueIndex);
+        String newValue = Descriptor.rename(value, oldname, newname);
+        setValue(Descriptor.toClassName(newValue));
+    }
+
+    @Override
+    public void renameClass(Map<String, String> classnames) {
+        String value = cp.getUtf8Info(valueIndex);
+        String newValue = Descriptor.rename(value, classnames);
+        setValue(Descriptor.toClassName(newValue));
     }
 
     /**

--- a/src/main/javassist/bytecode/annotation/EnumMemberValue.java
+++ b/src/main/javassist/bytecode/annotation/EnumMemberValue.java
@@ -18,6 +18,7 @@ package javassist.bytecode.annotation;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import javassist.ClassPool;
 import javassist.bytecode.ConstPool;
@@ -74,6 +75,20 @@ public class EnumMemberValue extends MemberValue {
     @Override
     Class<?> getType(ClassLoader cl) throws ClassNotFoundException {
         return loadClass(cl, getType());
+    }
+
+    @Override
+    public void renameClass(String oldname, String newname) {
+        String type = cp.getUtf8Info(typeIndex);
+        String newType = Descriptor.rename(type, oldname, newname);
+        setType(Descriptor.toClassName(newType));
+    }
+
+    @Override
+    public void renameClass(Map<String, String> classnames) {
+        String type = cp.getUtf8Info(typeIndex);
+        String newType = Descriptor.rename(type, classnames);
+        setType(Descriptor.toClassName(newType));
     }
 
     /**

--- a/src/main/javassist/bytecode/annotation/MemberValue.java
+++ b/src/main/javassist/bytecode/annotation/MemberValue.java
@@ -18,6 +18,7 @@ package javassist.bytecode.annotation;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import javassist.ClassPool;
 import javassist.bytecode.ConstPool;
@@ -73,6 +74,14 @@ public abstract class MemberValue {
         }
         return classname;
     }
+
+    /* The following two methods are used to implement
+     * ClassFile.renameClass().
+     * Only ArrayMemberValue, ClassMemberValue, EnumMemberValue
+     * override these methods.
+     */
+    public void renameClass(String oldname, String newname) {}
+    public void renameClass(Map<String, String> classnames) {}
 
     /**
      * Accepts a visitor.

--- a/src/test/javassist/bytecode/BytecodeTest.java
+++ b/src/test/javassist/bytecode/BytecodeTest.java
@@ -472,10 +472,14 @@ public class BytecodeTest extends TestCase {
         changeMsig2("<S:Ljava/lang/Object;>(TS;[TS;)Ljava/lang/Objec;", "java/lang/Object",
                     "<S:Ljava/lang/Object2;>(TS;[TS;)Ljava/lang/Objec;", "java/lang/Object2"); 
         String sig = "<T:Ljava/lang/Exception;>LPoi$Foo<Ljava/lang/String;>;LBar;LBar2;";
-        //String res = "<T:Ljava/lang/Exception;>LPoi$Foo<Ljava/lang/String2;>;LBar;LBar2;";
-        changeMsig(sig, "java/lang/String", sig, "java/lang/String2");
-        changeMsig2(sig, "java/lang/String", sig, "java/lang/String2");
-        changeMsig("Ltest<TE;>.List;", "ist", "Ltest<TE;>.List;", "IST");
+        String res = "<T:Ljava/lang/Exception;>LPoi$Foo<Ljava/lang/String2;>;LBar;LBar2;";
+        changeMsig(sig, "java/lang/String", res, "java/lang/String2");
+        changeMsig2(sig, "java/lang/String", res, "java/lang/String2");
+        //changeMsig("Ltest<TE;>.List;", "ist", "Ltest<TE;>.List;", "IST");
+        changeMsig("Ljava/lang/String<Ljava/lang/Object;>;", "java/lang/String",
+                   "Ljava/lang/String2<Ljava/lang/Object;>;", "java/lang/String2");
+        changeMsig2("Ljava/lang/String<Ljava/lang/Object;>;", "java/lang/String",
+                   "Ljava/lang/String2<Ljava/lang/Object;>;", "java/lang/String2");
     }
 
     private void changeMsig(String old, String oldname, String result, String newname) {


### PR DESCRIPTION
I found two cases that failed to rename the class name:

- case 1:
  SignatureAttribute: Generics descriptor could not be successfully renamed; `Lcom/squareup/wire/TagMap<Lcom/squareup/wire/MessageAdapter$FieldInfo;>;`

- case 2:
  AnnotationDefaultAttribute: It has not been renamed.
```
package com.test.member.value;

import com.squareup.wire.Message;

public @interface TestMemberValue {
    Message.Datatype type() default Message.Datatype.MESSAGE;

    Message.Label[] labels() default {Message.Label.OPTIONAL, Message.Label.PACKED};

    Class<?> clazz() default TestMemberValue.class;

    Class[] clazzs() default {TestMemberValue.class};
}
```

Note the map：
```
com/squareup/wire/TagMap : com/squareup/wire/test/TagMap
com/squareup/wire/MessageAdapter$FieldInfo : com/squareup/wire/test/MessageAdapter$FieldInfo
...
com/squareup/wire/** : com/squareup/wire/test/**
com/test/member/value/TestMemberValue : com/test/test/test/member/value/TestMemberValue
```

The problem was fixed by this pr.