### PR TITLE
Fix typo in TypeChecker

### DIFF
--- a/src/main/javassist/compiler/TypeChecker.java
+++ b/src/main/javassist/compiler/TypeChecker.java
@@ -933,7 +933,7 @@ public class TypeChecker extends Visitor implements Opcode, TokenId {
             }
         }
 
-        throw new CompileError("bad filed access");
+        throw new CompileError("bad field access");
     }
 
     private CtField fieldAccess2(Expr e, String jvmClassName) throws CompileError {


### PR DESCRIPTION
Should be "bad field access" not "bad filed access".