### PR TITLE
add functions for getting the parameter names of method

### DIFF
--- a/src/main/javassist/bytecode/LocalVariableAttribute.java
+++ b/src/main/javassist/bytecode/LocalVariableAttribute.java
@@ -218,6 +218,22 @@ public class LocalVariableAttribute extends AttributeInfo {
     }
 
     /**
+     * Returns the name of the local variable with given index.
+     * If you want get the parameter name of method with correct order,
+     * should using this method.
+     *
+     * @param index         the index of the local variable.
+     */
+    public String variableNameByIndex(int index) {
+        for (int i = 0; i < tableLength(); i++) {
+            if (index(i) == index) {
+                return getConstPool().getUtf8Info(nameIndex(i));
+            }
+        }
+        throw new ArrayIndexOutOfBoundsException();
+    }
+
+    /**
      * Returns the value of
      * <code>local_variable_table[i].descriptor_index</code>.
      * This represents the type descriptor of the local variable.

--- a/src/main/javassist/bytecode/LocalVariableAttribute.java
+++ b/src/main/javassist/bytecode/LocalVariableAttribute.java
@@ -227,7 +227,7 @@ public class LocalVariableAttribute extends AttributeInfo {
     public String variableNameByIndex(int index) {
         for (int i = 0; i < tableLength(); i++) {
             if (index(i) == index) {
-                return getConstPool().getUtf8Info(nameIndex(i));
+                return variableName(i);
             }
         }
         throw new ArrayIndexOutOfBoundsException();

--- a/src/main/javassist/bytecode/MethodParametersAttribute.java
+++ b/src/main/javassist/bytecode/MethodParametersAttribute.java
@@ -57,6 +57,14 @@ public class MethodParametersAttribute extends AttributeInfo {
     }
 
     /**
+     * Returns the name of the i-th element of <code>parameters</code>.
+     * @param i         the position of the parameter.
+     */
+    public String parameterName(int i) {
+        return getConstPool().getUtf8Info(name(i));
+    }
+
+    /**
      * Returns the value of <code>access_flags</code> of the i-th element of <code>parameters</code>.
      *
      * @param i         the position of the parameter.

--- a/src/test/javassist/JvstTest4.java
+++ b/src/test/javassist/JvstTest4.java
@@ -1019,11 +1019,15 @@ public class JvstTest4 extends JvstTestRoot {
         assertEquals(2, attr.size());
         assertEquals("i", cp.getUtf8Info(attr.name(0)));
         assertEquals("s", cp.getUtf8Info(attr.name(1)));
+        assertEquals("i", attr.parameterName(0));
+        assertEquals("s", attr.parameterName(1));
 
         attr = (MethodParametersAttribute)attr.copy(cp, null);
         assertEquals(2, attr.size());
         assertEquals("i", cp.getUtf8Info(attr.name(0)));
         assertEquals("s", cp.getUtf8Info(attr.name(1)));
+        assertEquals("i", attr.parameterName(0));
+        assertEquals("s", attr.parameterName(1));
     }
 
     // JIRA JASSIST-220

--- a/src/test/javassist/bytecode/BytecodeTest.java
+++ b/src/test/javassist/bytecode/BytecodeTest.java
@@ -354,6 +354,9 @@ public class BytecodeTest extends TestCase {
                 assertEquals("I", ainfo2.descriptor(i));
         }
         print("**** end ***");
+
+        assertEquals("this", ainfo2.variableNameByIndex(0));
+        assertEquals("i", ainfo2.variableNameByIndex(1));
     }
 
     public void testAnnotations() throws Exception {


### PR DESCRIPTION
 1. Add function in `LocalVariableAttribute.java` for getting correct local variable name by given index. The `variableName` method has some ambiguities for get the parameter names of method, see #14 , #16 , #131 . The `local_variable_table` may appear in any order, so `variableName` method give incorrect value.
 2. Add function in `MethodParametersAttribute.java` for getting parameter names.