### PR TITLE
Replace StringBuffer with StringBuilder, other minor String optimizations

### DIFF
--- a/src/main/javassist/ClassPoolTail.java
+++ b/src/main/javassist/ClassPoolTail.java
@@ -54,7 +54,7 @@ final class DirClassPath implements ClassPath {
             char sep = File.separatorChar;
             String filename = directory + sep
                 + classname.replace('.', sep) + ".class";
-            return new FileInputStream(filename.toString());
+            return new FileInputStream(filename);
         }
         catch (FileNotFoundException e) {}
         catch (SecurityException e) {}
@@ -187,7 +187,7 @@ final class JarClassPath implements ClassPath {
 
     @Override
     public String toString() {
-        return jarfileURL == null ? "<null>" : jarfileURL.toString();
+        return jarfileURL == null ? "<null>" : jarfileURL;
     }
 }
 
@@ -200,7 +200,7 @@ final class ClassPoolTail {
 
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("[class path: ");
         ClassPathList list = pathList;
         while (list != null) {

--- a/src/main/javassist/CtBehavior.java
+++ b/src/main/javassist/CtBehavior.java
@@ -100,7 +100,7 @@ public abstract class CtBehavior extends CtMember {
     }
 
     @Override
-    protected void extendToString(StringBuffer buffer) {
+    protected void extendToString(StringBuilder buffer) {
         buffer.append(' ');
         buffer.append(getName());
         buffer.append(' ');

--- a/src/main/javassist/CtClass.java
+++ b/src/main/javassist/CtClass.java
@@ -200,12 +200,12 @@ public abstract class CtClass {
      */
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer(getClass().getName());
-        buf.append("@");
+        StringBuilder buf = new StringBuilder(getClass().getName());
+        buf.append('@');
         buf.append(Integer.toHexString(hashCode()));
-        buf.append("[");
+        buf.append('[');
         extendToString(buf);
-        buf.append("]");
+        buf.append(']');
         return buf.toString();
     }
 
@@ -213,7 +213,7 @@ public abstract class CtClass {
      * Implemented in subclasses to add to the {@link #toString()} result.
      * Subclasses should put a space before each token added to the buffer.
      */
-    protected void extendToString(StringBuffer buffer) {
+    protected void extendToString(StringBuilder buffer) {
         buffer.append(getName());
     }
 

--- a/src/main/javassist/CtClassType.java
+++ b/src/main/javassist/CtClassType.java
@@ -106,7 +106,7 @@ class CtClassType extends CtClass {
     }
 
     @Override
-    protected void extendToString(StringBuffer buffer) {
+    protected void extendToString(StringBuilder buffer) {
         if (wasChanged)
             buffer.append("changed ");
 
@@ -125,7 +125,7 @@ class CtClassType extends CtClass {
             if (ext != null) {
                 String name = ext.getName();
                 if (!name.equals("java.lang.Object"))
-                    buffer.append(" extends " + ext.getName());
+                    buffer.append(" extends ").append(ext.getName());
             }
         }
         catch (NotFoundException e) {
@@ -155,7 +155,7 @@ class CtClassType extends CtClass {
                    memCache.methodHead(), memCache.lastMethod());
     }
 
-    private void exToString(StringBuffer buffer, String msg,
+    private void exToString(StringBuilder buffer, String msg,
                             CtMember head, CtMember tail) {
         buffer.append(msg);
         while (head != tail) {

--- a/src/main/javassist/CtField.java
+++ b/src/main/javassist/CtField.java
@@ -128,7 +128,7 @@ public class CtField extends CtMember {
     }
 
     @Override
-    protected void extendToString(StringBuffer buffer) {
+    protected void extendToString(StringBuilder buffer) {
         buffer.append(' ');
         buffer.append(getName());
         buffer.append(' ');

--- a/src/main/javassist/CtMember.java
+++ b/src/main/javassist/CtMember.java
@@ -30,7 +30,7 @@ public abstract class CtMember {
      */
     static class Cache extends CtMember {
         @Override
-        protected void extendToString(StringBuffer buffer) {}
+        protected void extendToString(StringBuilder buffer) {}
         @Override
         public boolean hasAnnotation(String clz) { return false; }
         @Override
@@ -155,13 +155,13 @@ public abstract class CtMember {
 
     @Override
     public String toString() {
-        StringBuffer buffer = new StringBuffer(getClass().getName());
-        buffer.append("@");
+        StringBuilder buffer = new StringBuilder(getClass().getName());
+        buffer.append('@');
         buffer.append(Integer.toHexString(hashCode()));
-        buffer.append("[");
+        buffer.append('[');
         buffer.append(Modifier.toString(getModifiers()));
         extendToString(buffer);
-        buffer.append("]");
+        buffer.append(']');
         return buffer.toString();
     }
 
@@ -172,7 +172,7 @@ public abstract class CtMember {
      * provided first; subclasses should provide additional data such
      * as return type, field or method name, etc.
      */
-    protected abstract void extendToString(StringBuffer buffer);
+    protected abstract void extendToString(StringBuilder buffer);
 
     /**
      * Returns the class that declares this member.

--- a/src/main/javassist/CtNewClass.java
+++ b/src/main/javassist/CtNewClass.java
@@ -45,7 +45,7 @@ class CtNewClass extends CtClassType {
     }
 
     @Override
-    protected void extendToString(StringBuffer buffer) {
+    protected void extendToString(StringBuilder buffer) {
         if (hasConstructor)
             buffer.append("hasConstructor ");
 

--- a/src/main/javassist/bytecode/Descriptor.java
+++ b/src/main/javassist/bytecode/Descriptor.java
@@ -109,7 +109,7 @@ public class Descriptor {
 
         if (arrayDim == 0)
             return name;
-        StringBuffer sbuf = new StringBuffer(name);
+        StringBuilder sbuf = new StringBuilder(name);
         do {
             sbuf.append("[]");
         } while (--arrayDim > 0);
@@ -157,7 +157,7 @@ public class Descriptor {
         if (desc.indexOf(oldname) < 0)
             return desc;
 
-        StringBuffer newdesc = new StringBuffer();
+        StringBuilder newdesc = new StringBuilder();
         int head = 0;
         int i = 0;
         for (;;) {
@@ -200,7 +200,7 @@ public class Descriptor {
         if (map == null)
             return desc;
 
-        StringBuffer newdesc = new StringBuffer();
+        StringBuilder newdesc = new StringBuilder();
         int head = 0;
         int i = 0;
         for (;;) {
@@ -237,12 +237,12 @@ public class Descriptor {
      * Returns the descriptor representing the given type.
      */
     public static String of(CtClass type) {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         toDescriptor(sbuf, type);
         return sbuf.toString();
     }
 
-    private static void toDescriptor(StringBuffer desc, CtClass type) {
+    private static void toDescriptor(StringBuilder desc, CtClass type) {
         if (type.isArray()) {
             desc.append('[');
             try {
@@ -284,7 +284,7 @@ public class Descriptor {
      * @param paramTypes parameter types
      */
     public static String ofMethod(CtClass returnType, CtClass[] paramTypes) {
-        StringBuffer desc = new StringBuffer();
+        StringBuilder desc = new StringBuilder();
         desc.append('(');
         if (paramTypes != null) {
             int n = paramTypes.length;
@@ -323,7 +323,7 @@ public class Descriptor {
         int i = desc.indexOf(')');
         if (i < 0)
             return desc;
-        StringBuffer newdesc = new StringBuffer();
+        StringBuilder newdesc = new StringBuilder();
         newdesc.append(desc.substring(0, i));
         newdesc.append('L');
         newdesc.append(classname.replace('.', '/'));
@@ -361,7 +361,7 @@ public class Descriptor {
         int i = descriptor.indexOf(')');
         if (i < 0)
             return descriptor;
-        StringBuffer newdesc = new StringBuffer();
+        StringBuilder newdesc = new StringBuilder();
         newdesc.append(descriptor.substring(0, i));
         toDescriptor(newdesc, type);
         newdesc.append(descriptor.substring(i));
@@ -395,7 +395,7 @@ public class Descriptor {
         int i = desc.indexOf(')');
         if (i < 0)
             return desc;
-        StringBuffer newdesc = new StringBuffer();
+        StringBuilder newdesc = new StringBuilder();
         newdesc.append(desc.substring(0, i + 1));
         newdesc.append('L');
         newdesc.append(classname.replace('.', '/'));
@@ -561,7 +561,7 @@ public class Descriptor {
         }
 
         if (arrayDim > 0) {
-            StringBuffer sbuf = new StringBuffer(name);
+            StringBuilder sbuf = new StringBuilder(name);
             while (arrayDim-- > 0)
                 sbuf.append("[]");
 
@@ -719,7 +719,7 @@ public class Descriptor {
 
     static class PrettyPrinter {
         static String toString(String desc) {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
             if (desc.charAt(0) == '(') {
                 int pos = 1;
                 sbuf.append('(');
@@ -738,7 +738,7 @@ public class Descriptor {
             return sbuf.toString();
         }
 
-        static int readType(StringBuffer sbuf, int pos, String desc) {
+        static int readType(StringBuilder sbuf, int pos, String desc) {
             char c = desc.charAt(pos);
             int arrayDim = 0;
             while (c == '[') {

--- a/src/main/javassist/bytecode/InstructionPrinter.java
+++ b/src/main/javassist/bytecode/InstructionPrinter.java
@@ -235,17 +235,17 @@ public class InstructionPrinter implements Opcode {
 
 
     private static String lookupSwitch(CodeIterator iter, int pos) {
-        StringBuffer buffer = new StringBuffer("lookupswitch {\n");
+        StringBuilder buffer = new StringBuilder("lookupswitch {\n");
         int index = (pos & ~3) + 4;
         // default
-        buffer.append("\t\tdefault: ").append(pos + iter.s32bitAt(index)).append("\n");
+        buffer.append("\t\tdefault: ").append(pos + iter.s32bitAt(index)).append('\n');
         int npairs = iter.s32bitAt(index += 4);
         int end = npairs * 8 + (index += 4);
 
         for (; index < end; index += 8) {
             int match = iter.s32bitAt(index);
             int target = iter.s32bitAt(index + 4) + pos;
-            buffer.append("\t\t").append(match).append(": ").append(target).append("\n");
+            buffer.append("\t\t").append(match).append(": ").append(target).append('\n');
         }
 
         buffer.setCharAt(buffer.length() - 1, '}');
@@ -254,10 +254,10 @@ public class InstructionPrinter implements Opcode {
 
 
     private static String tableSwitch(CodeIterator iter, int pos) {
-        StringBuffer buffer = new StringBuffer("tableswitch {\n");
+        StringBuilder buffer = new StringBuilder("tableswitch {\n");
         int index = (pos & ~3) + 4;
         // default
-        buffer.append("\t\tdefault: ").append(pos + iter.s32bitAt(index)).append("\n");
+        buffer.append("\t\tdefault: ").append(pos + iter.s32bitAt(index)).append('\n');
         int low = iter.s32bitAt(index += 4);
         int high = iter.s32bitAt(index += 4);
         int end = (high - low + 1) * 4 + (index += 4);
@@ -265,7 +265,7 @@ public class InstructionPrinter implements Opcode {
         // Offset table
         for (int key = low; index < end; index += 4, key++) {
             int target = iter.s32bitAt(index) + pos;
-            buffer.append("\t\t").append(key).append(": ").append(target).append("\n");
+            buffer.append("\t\t").append(key).append(": ").append(target).append('\n');
         }
 
         buffer.setCharAt(buffer.length() - 1, '}');

--- a/src/main/javassist/bytecode/ParameterAnnotationsAttribute.java
+++ b/src/main/javassist/bytecode/ParameterAnnotationsAttribute.java
@@ -201,7 +201,7 @@ public class ParameterAnnotationsAttribute extends AttributeInfo {
         StringBuilder sbuf = new StringBuilder();
         for (Annotation[] a : aa) {
             for (Annotation i : a)
-                sbuf.append(i.toString()).append(" ");
+                sbuf.append(i.toString()).append(' ');
 
             sbuf.append(", ");
         }

--- a/src/main/javassist/bytecode/SignatureAttribute.java
+++ b/src/main/javassist/bytecode/SignatureAttribute.java
@@ -431,7 +431,7 @@ public class SignatureAttribute extends AttributeInfo {
          */
         @Override
         public String toString() {
-            StringBuffer sbuf = new StringBuffer(getName());
+            StringBuilder sbuf = new StringBuilder(getName());
             if (superClass != null)
                 sbuf.append(" extends ").append(superClass.toString());
 
@@ -740,7 +740,7 @@ public class SignatureAttribute extends AttributeInfo {
          */
         @Override
         public String toString() {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
             ClassType parent = getDeclaringClass();
             if (parent != null)
                 sbuf.append(parent.toString()).append('.');
@@ -748,7 +748,7 @@ public class SignatureAttribute extends AttributeInfo {
             return toString2(sbuf);
         }
 
-        private String toString2(StringBuffer sbuf) {
+        private String toString2(StringBuilder sbuf) {
             sbuf.append(name);
             if (arguments != null) {
                 sbuf.append('<');
@@ -773,7 +773,7 @@ public class SignatureAttribute extends AttributeInfo {
          */
         @Override
         public String jvmTypeName() {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
             ClassType parent = getDeclaringClass();
             if (parent != null)
                 sbuf.append(parent.jvmTypeName()).append('$');
@@ -868,7 +868,7 @@ public class SignatureAttribute extends AttributeInfo {
          */
         @Override
         public String toString() {
-            StringBuffer sbuf = new StringBuffer(componentType.toString());
+            StringBuilder sbuf = new StringBuilder(componentType.toString());
             for (int i = 0; i < dim; i++)
                 sbuf.append("[]");
 

--- a/src/main/javassist/bytecode/SignatureAttribute.java
+++ b/src/main/javassist/bytecode/SignatureAttribute.java
@@ -230,7 +230,7 @@ public class SignatureAttribute extends AttributeInfo {
          */
         @Override
         public String toString() {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
 
             TypeParameter.toString(sbuf, params);
             sbuf.append(" extends ").append(superClass);
@@ -246,7 +246,7 @@ public class SignatureAttribute extends AttributeInfo {
          * Returns the encoded string representing the method type signature.
          */
         public String encode() {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
             if (params.length > 0) {
                 sbuf.append('<');
                 for (int i = 0; i < params.length; i++)
@@ -320,7 +320,7 @@ public class SignatureAttribute extends AttributeInfo {
          */
         @Override
         public String toString() {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
 
             TypeParameter.toString(sbuf, typeParams);
             sbuf.append(" (");
@@ -339,7 +339,7 @@ public class SignatureAttribute extends AttributeInfo {
          * Returns the encoded string representing the method type signature.
          */
         public String encode() {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
             if (typeParams.length > 0) {
                 sbuf.append('<');
                 for (int i = 0; i < typeParams.length; i++)
@@ -450,7 +450,7 @@ public class SignatureAttribute extends AttributeInfo {
             return sbuf.toString();
         }
 
-        static void toString(StringBuffer sbuf, TypeParameter[] tp) {
+        static void toString(StringBuilder sbuf, TypeParameter[] tp) {
             sbuf.append('<');
             for (int i = 0; i < tp.length; i++) {
                 if (i > 0)
@@ -462,7 +462,7 @@ public class SignatureAttribute extends AttributeInfo {
             sbuf.append('>');
         }
 
-        void encode(StringBuffer sb) {
+        void encode(StringBuilder sb) {
             sb.append(name);
             if (superClass == null)
                 sb.append(":Ljava/lang/Object;");
@@ -570,7 +570,7 @@ public class SignatureAttribute extends AttributeInfo {
                 return "? super " + type;
         }
 
-        static void encode(StringBuffer sb, TypeArgument[] args) {
+        static void encode(StringBuilder sb, TypeArgument[] args) {
             sb.append('<');
             for (int i = 0; i < args.length; i++) {
                 TypeArgument ta = args[i];
@@ -589,8 +589,8 @@ public class SignatureAttribute extends AttributeInfo {
      * Primitive types and object types.
      */
     public static abstract class Type {
-        abstract void encode(StringBuffer sb);
-        static void toString(StringBuffer sbuf, Type[] ts) {
+        abstract void encode(StringBuilder sb);
+        static void toString(StringBuilder sbuf, Type[] ts) {
             for (int i = 0; i < ts.length; i++) {
                 if (i > 0)
                     sbuf.append(", ");
@@ -647,7 +647,7 @@ public class SignatureAttribute extends AttributeInfo {
         }
 
         @Override
-        void encode(StringBuffer sb) {
+        void encode(StringBuilder sb) {
             sb.append(descriptor);
         }
     }
@@ -661,7 +661,7 @@ public class SignatureAttribute extends AttributeInfo {
          * Returns the encoded string representing the object type signature.
          */
         public String encode() {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             encode(sb);
             return sb.toString();
         }
@@ -782,13 +782,13 @@ public class SignatureAttribute extends AttributeInfo {
         }
 
         @Override
-        void encode(StringBuffer sb) {
+        void encode(StringBuilder sb) {
             sb.append('L');
             encode2(sb);
             sb.append(';');
         }
 
-        void encode2(StringBuffer sb) {
+        void encode2(StringBuilder sb) {
             ClassType parent = getDeclaringClass();
             if (parent != null) {
                 parent.encode2(sb);
@@ -876,7 +876,7 @@ public class SignatureAttribute extends AttributeInfo {
         }
 
         @Override
-        void encode(StringBuffer sb) {
+        void encode(StringBuilder sb) {
             for (int i = 0; i < dim; i++)
                 sb.append('[');
 
@@ -919,7 +919,7 @@ public class SignatureAttribute extends AttributeInfo {
         }
 
         @Override
-        void encode(StringBuffer sb) {
+        void encode(StringBuilder sb) {
             sb.append('T').append(name).append(';');
         }
     }

--- a/src/main/javassist/bytecode/analysis/ControlFlow.java
+++ b/src/main/javassist/bytecode/analysis/ControlFlow.java
@@ -261,13 +261,13 @@ public class ControlFlow {
         }
 
         @Override
-        protected void toString2(StringBuffer sbuf) {
+        protected void toString2(StringBuilder sbuf) {
             super.toString2(sbuf);
             sbuf.append(", incoming{");
             for (int i = 0; i < entrances.length; i++)
                     sbuf.append(entrances[i].position).append(", ");
 
-            sbuf.append("}");
+            sbuf.append('}');
         }
 
         BasicBlock[] getExit() { return exit; }
@@ -360,7 +360,7 @@ public class ControlFlow {
          */
         @Override
         public String toString() {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
             sbuf.append("Node[pos=").append(block().position());
             sbuf.append(", parent=");
             sbuf.append(parent == null ? "*" : Integer.toString(parent.block().position()));

--- a/src/main/javassist/bytecode/analysis/Frame.java
+++ b/src/main/javassist/bytecode/analysis/Frame.java
@@ -231,7 +231,7 @@ public class Frame {
 
     @Override
     public String toString() {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
 
         buffer.append("locals = [");
         for (int i = 0; i < locals.length; i++) {
@@ -245,7 +245,7 @@ public class Frame {
             if (i < top - 1)
                 buffer.append(", ");
         }
-        buffer.append("]");
+        buffer.append(']');
 
         return buffer.toString();
     }

--- a/src/main/javassist/bytecode/analysis/MultiType.java
+++ b/src/main/javassist/bytecode/analysis/MultiType.java
@@ -312,14 +312,15 @@ public class MultiType extends Type {
         if (resolved != null)
             return resolved.toString();
 
-        StringBuffer buffer = new StringBuffer("{");
+        StringBuilder buffer = new StringBuilder();
+        buffer.append('{');
         for (String key:interfaces.keySet())
             buffer.append(key).append(", ");
         if (potentialClass != null)
-            buffer.append("*").append(potentialClass.toString());
+            buffer.append('*').append(potentialClass.toString());
         else
             buffer.setLength(buffer.length() - 2);
-        buffer.append("}");
+        buffer.append('}');
         return buffer.toString();
     }
 }

--- a/src/main/javassist/bytecode/annotation/Annotation.java
+++ b/src/main/javassist/bytecode/annotation/Annotation.java
@@ -210,17 +210,18 @@ public class Annotation {
      */
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer("@");
+        StringBuilder buf = new StringBuilder();
+        buf.append('@');
         buf.append(getTypeName());
         if (members != null) {
-            buf.append("(");
+            buf.append('(');
             for (String name:members.keySet()) {
-                buf.append(name).append("=")
+                buf.append(name).append('=')
                    .append(getMemberValue(name))
                    .append(", ");
             }
             buf.setLength(buf.length()-2);
-            buf.append(")");
+            buf.append(')');
         }
 
         return buf.toString();

--- a/src/main/javassist/bytecode/annotation/ArrayMemberValue.java
+++ b/src/main/javassist/bytecode/annotation/ArrayMemberValue.java
@@ -117,7 +117,8 @@ public class ArrayMemberValue extends MemberValue {
      */
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer("{");
+        StringBuilder buf = new StringBuilder();
+        buf.append('{');
         if (values != null) {
             for (int i = 0; i < values.length; i++) {
                 buf.append(values[i].toString());
@@ -126,7 +127,7 @@ public class ArrayMemberValue extends MemberValue {
                 }
         }
 
-        buf.append("}");
+        buf.append('}');
         return buf.toString();
     }
 

--- a/src/main/javassist/bytecode/annotation/MemberValue.java
+++ b/src/main/javassist/bytecode/annotation/MemberValue.java
@@ -64,9 +64,9 @@ public abstract class MemberValue {
         int index = classname.indexOf("[]");
         if (index != -1) {
             String rawType = classname.substring(0, index);
-            StringBuffer sb = new StringBuffer(Descriptor.of(rawType));
+            StringBuilder sb = new StringBuilder(Descriptor.of(rawType));
             while (index != -1) {
-                sb.insert(0, "[");
+                sb.insert(0, '[');
                 index = classname.indexOf("[]", index + 1);
             }
             return sb.toString().replace('/', '.');

--- a/src/main/javassist/bytecode/stackmap/BasicBlock.java
+++ b/src/main/javassist/bytecode/stackmap/BasicBlock.java
@@ -78,33 +78,33 @@ public class BasicBlock {
 
     @Override
     public String toString() {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         String cname = this.getClass().getName();
         int i = cname.lastIndexOf('.');
         sbuf.append(i < 0 ? cname : cname.substring(i + 1));
-        sbuf.append("[");
+        sbuf.append('[');
         toString2(sbuf);
-        sbuf.append("]");
+        sbuf.append(']');
         return sbuf.toString();
     }
 
-    protected void toString2(StringBuffer sbuf) {
+    protected void toString2(StringBuilder sbuf) {
         sbuf.append("pos=").append(position).append(", len=")
             .append(length).append(", in=").append(incoming)
             .append(", exit{");
         if (exit != null)
             for (BasicBlock b:exit)
-                sbuf.append(b.position).append(",");
+                sbuf.append(b.position).append(',');
 
         sbuf.append("}, {");
         Catch th = toCatch;
         while (th != null) {
-            sbuf.append("(").append(th.body.position).append(", ")
+            sbuf.append('(').append(th.body.position).append(", ")
                 .append(th.typeIndex).append("), ");
             th = th.next;
         }
 
-        sbuf.append("}");
+        sbuf.append('}');
     }
 
     /**

--- a/src/main/javassist/bytecode/stackmap/TypeData.java
+++ b/src/main/javassist/bytecode/stackmap/TypeData.java
@@ -434,7 +434,7 @@ public abstract class TypeData {
 
         private String fixTypes2(List<TypeData> scc, Set<String> lowersSet, ClassPool cp) throws NotFoundException {
             Iterator<String> it = lowersSet.iterator();
-            if (lowersSet.size() == 0)
+            if (lowersSet.isEmpty())
                 return null;      // only NullType
             else if (lowersSet.size() == 1)
                 return it.next();

--- a/src/main/javassist/bytecode/stackmap/TypedBlock.java
+++ b/src/main/javassist/bytecode/stackmap/TypedBlock.java
@@ -59,7 +59,7 @@ public class TypedBlock extends BasicBlock {
     }
 
     @Override
-    protected void toString2(StringBuffer sbuf) {
+    protected void toString2(StringBuilder sbuf) {
         super.toString2(sbuf);
         sbuf.append(",\n stack={");
         printTypes(sbuf, stackTop, stackTypes);
@@ -68,7 +68,7 @@ public class TypedBlock extends BasicBlock {
         sbuf.append('}');
     }
 
-    private void printTypes(StringBuffer sbuf, int size,
+    private void printTypes(StringBuilder sbuf, int size,
                             TypeData[] types) {
         if (types == null)
             return;

--- a/src/main/javassist/compiler/CodeGen.java
+++ b/src/main/javassist/compiler/CodeGen.java
@@ -197,7 +197,7 @@ public abstract class CodeGen extends Visitor implements Opcode, TokenId {
 
         if (dim == 0)
             return name;
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         int d = dim;
         while (d-- > 0)
             sbuf.append('[');
@@ -241,7 +241,7 @@ public abstract class CodeGen extends Visitor implements Opcode, TokenId {
             break;
         }
 
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         while (dim-- > 0)
                 sbuf.append('[');
 
@@ -473,7 +473,7 @@ public abstract class CodeGen extends Visitor implements Opcode, TokenId {
         boolean alwaysBranch = compileBooleanExpr(true, expr);
         if (alwaysBranch) {
             bytecode.addOpcode(Opcode.GOTO);
-            alwaysBranch = breakList.size() == 0;
+            alwaysBranch = breakList.isEmpty();
         }
 
         bytecode.addIndex(pc2 - bytecode.currentPc() + 1);
@@ -1663,7 +1663,7 @@ public abstract class CodeGen extends Visitor implements Opcode, TokenId {
                      * must be passed to Class.forName().
                      */
                     name2 = MemberResolver.jvmToJavaName(name2);
-                    StringBuffer sbuf = new StringBuffer();
+                    StringBuilder sbuf = new StringBuilder();
                     while (i-- >= 0)
                         sbuf.append('[');
 

--- a/src/main/javassist/compiler/JvstCodeGen.java
+++ b/src/main/javassist/compiler/JvstCodeGen.java
@@ -264,7 +264,7 @@ public class JvstCodeGen extends MemberCodeGen {
     /* To support $cflow().
      */
     protected void atCflow(ASTList cname) throws CompileError {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         if (cname == null || cname.tail() != null)
             throw new CompileError("bad " + cflowName);
 
@@ -288,7 +288,7 @@ public class JvstCodeGen extends MemberCodeGen {
      * <cflow> : $cflow '(' <cflow name> ')'
      * <cflow name> : <identifier> ('.' <identifier>)*
      */
-    private static void makeCflowName(StringBuffer sbuf, ASTree name)
+    private static void makeCflowName(StringBuilder sbuf, ASTree name)
         throws CompileError
     {
         if (name instanceof Symbol) {

--- a/src/main/javassist/compiler/Lex.java
+++ b/src/main/javassist/compiler/Lex.java
@@ -27,7 +27,7 @@ class Token {
 
 public class Lex implements TokenId {
     private int lastChar;
-    private StringBuffer textBuffer;
+    private StringBuilder textBuffer;
     private Token currentToken;
     private Token lookAheadTokens;
 
@@ -40,7 +40,7 @@ public class Lex implements TokenId {
      */
     public Lex(String s) {
         lastChar = -1;
-        textBuffer = new StringBuffer();
+        textBuffer = new StringBuilder();
         currentToken = new Token();
         lookAheadTokens = null;
 
@@ -123,7 +123,7 @@ public class Lex implements TokenId {
         else if(c == '.'){
             c = getc();
             if ('0' <= c && c <= '9') {
-                StringBuffer tbuf = textBuffer;
+                StringBuilder tbuf = textBuffer;
                 tbuf.setLength(0);
                 tbuf.append('.');
                 return readDouble(tbuf, c, token);
@@ -205,7 +205,7 @@ public class Lex implements TokenId {
 
     private int readStringL(Token token) {
         int c;
-        StringBuffer tbuf = textBuffer;
+        StringBuilder tbuf = textBuffer;
         tbuf.setLength(0);
         for (;;) {
             while ((c = getc()) != '"') {
@@ -287,7 +287,7 @@ public class Lex implements TokenId {
         }
         else if (c2 == 'E' || c2 == 'e'
                  || c2 == 'D' || c2 == 'd' || c2 == '.') {
-            StringBuffer tbuf = textBuffer;
+            StringBuilder tbuf = textBuffer;
             tbuf.setLength(0);
             tbuf.append(value);
             return readDouble(tbuf, c2, token);
@@ -300,7 +300,7 @@ public class Lex implements TokenId {
         }
     }
 
-    private int readDouble(StringBuffer sbuf, int c, Token token) {
+    private int readDouble(StringBuilder sbuf, int c, Token token) {
         if (c != 'E' && c != 'e' && c != 'D' && c != 'd') {
             sbuf.append((char)c);
             for (;;) {
@@ -412,7 +412,7 @@ public class Lex implements TokenId {
     }
 
     private int readIdentifier(int c, Token token) {
-        StringBuffer tbuf = textBuffer;
+        StringBuilder tbuf = textBuffer;
         tbuf.setLength(0);
 
         do {

--- a/src/main/javassist/compiler/MemberResolver.java
+++ b/src/main/javassist/compiler/MemberResolver.java
@@ -491,7 +491,7 @@ public class MemberResolver implements TokenId {
                 int i = classname.lastIndexOf('.');
                 if (notCheckInner || i < 0)
                     throw e;
-                StringBuffer sbuf = new StringBuffer(classname);
+                StringBuilder sbuf = new StringBuilder(classname);
                 sbuf.setCharAt(i, '$');
                 classname = sbuf.toString();
             }

--- a/src/main/javassist/compiler/Parser.java
+++ b/src/main/javassist/compiler/Parser.java
@@ -1113,7 +1113,7 @@ public final class Parser implements TokenId {
     {
         String cname = toClassName(className);
         if (dim > 0) {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
             while (dim-- > 0)
                 sbuf.append('[');
 
@@ -1199,12 +1199,12 @@ public final class Parser implements TokenId {
     private String toClassName(ASTree name)
         throws CompileError
     {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         toClassName(name, sbuf);
         return sbuf.toString();
     }
 
-    private void toClassName(ASTree name, StringBuffer sbuf)
+    private void toClassName(ASTree name, StringBuilder sbuf)
         throws CompileError
     {
         if (name instanceof Symbol) {

--- a/src/main/javassist/compiler/TypeChecker.java
+++ b/src/main/javassist/compiler/TypeChecker.java
@@ -74,7 +74,7 @@ public class TypeChecker extends Visitor implements Opcode, TokenId {
      */
     protected static String argTypesToString(int[] types, int[] dims,
                                              String[] cnames) {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         sbuf.append('(');
         int n = types.length;
         if (n > 0) {
@@ -96,7 +96,7 @@ public class TypeChecker extends Visitor implements Opcode, TokenId {
      * Converts a tuple of exprType, arrayDim, and className
      * into a String object.
      */
-    protected static StringBuffer typeToString(StringBuffer sbuf,
+    protected static StringBuilder typeToString(StringBuilder sbuf,
                                         int type, int dim, String cname) {
         String s;
         if (type == CLASS)

--- a/src/main/javassist/compiler/ast/ASTList.java
+++ b/src/main/javassist/compiler/ast/ASTList.java
@@ -79,7 +79,7 @@ public class ASTList extends ASTree {
 
     @Override
     public String toString() {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         sbuf.append("(<");
         sbuf.append(getTag());
         sbuf.append('>');

--- a/src/main/javassist/compiler/ast/ASTree.java
+++ b/src/main/javassist/compiler/ast/ASTree.java
@@ -46,7 +46,7 @@ public abstract class ASTree implements Serializable {
 
     @Override
     public String toString() {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         sbuf.append('<');
         sbuf.append(getTag());
         sbuf.append('>');

--- a/src/main/javassist/compiler/ast/Declarator.java
+++ b/src/main/javassist/compiler/ast/Declarator.java
@@ -107,12 +107,12 @@ public class Declarator extends ASTList implements TokenId {
         if (name == null)
             return null;
 
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         astToClassName(sbuf, name, sep);
         return sbuf.toString();
     }
 
-    private static void astToClassName(StringBuffer sbuf, ASTList name,
+    private static void astToClassName(StringBuilder sbuf, ASTList name,
                                        char sep) {
         for (;;) {
             ASTree h = name.head();

--- a/src/main/javassist/compiler/ast/Pair.java
+++ b/src/main/javassist/compiler/ast/Pair.java
@@ -37,7 +37,7 @@ public class Pair extends ASTree {
 
     @Override
     public String toString() {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         sbuf.append("(<Pair> ");
         sbuf.append(left == null ? "<null>" : left.toString());
         sbuf.append(" . ");

--- a/src/main/javassist/convert/TransformAccessArrayField.java
+++ b/src/main/javassist/convert/TransformAccessArrayField.java
@@ -218,7 +218,7 @@ public final class TransformAccessArrayField extends Transformer {
             break;
         }
 
-        if (methodName.equals(""))
+        if ("".equals(methodName))
             methodName = null;
 
         return methodName;

--- a/src/main/javassist/tools/rmi/StubGenerator.java
+++ b/src/main/javassist/tools/rmi/StubGenerator.java
@@ -183,7 +183,7 @@ public class StubGenerator implements Translator {
         if (!rtclass.isArray())
             name = rtclass.getName();
         else {
-            StringBuffer sbuf = new StringBuffer();
+            StringBuilder sbuf = new StringBuilder();
             do {
                 sbuf.append("[]");
                 rtclass = rtclass.getComponentType();

--- a/src/main/javassist/tools/web/Webserver.java
+++ b/src/main/javassist/tools/web/Webserver.java
@@ -222,7 +222,7 @@ public class Webserver {
     }
 
     private String readLine(InputStream in) throws IOException {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         int c;
         while ((c = in.read()) >= 0 && c != 0x0d)
             buf.append((char)c);

--- a/src/main/javassist/util/proxy/ProxyFactory.java
+++ b/src/main/javassist/util/proxy/ProxyFactory.java
@@ -576,14 +576,14 @@ public class ProxyFactory {
 
     public String getKey(Class<?> superClass, Class<?>[] interfaces, byte[] signature, boolean useWriteReplace)
     {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         if (superClass != null){
             sbuf.append(superClass.getName());
         }
-        sbuf.append(":");
+        sbuf.append(':');
         for (int i = 0; i < interfaces.length; i++) {
             sbuf.append(interfaces[i].getName());
-            sbuf.append(":");
+            sbuf.append(':');
         }
         for (int i = 0; i < signature.length; i++) {
             byte b = signature[i];

--- a/src/main/javassist/util/proxy/RuntimeSupport.java
+++ b/src/main/javassist/util/proxy/RuntimeSupport.java
@@ -198,7 +198,7 @@ public class RuntimeSupport {
      * @param retType   return type.
      */
     public static String makeDescriptor(Class<?>[] params, Class<?> retType) {
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         sbuf.append('(');
         for (int i = 0; i < params.length; i++)
             makeDesc(sbuf, params[i]);
@@ -217,12 +217,12 @@ public class RuntimeSupport {
      * @param retType   return type.
      */
     public static String makeDescriptor(String params, Class<?> retType) {
-        StringBuffer sbuf = new StringBuffer(params);
+        StringBuilder sbuf = new StringBuilder(params);
         makeDesc(sbuf, retType);
         return sbuf.toString();
     }
 
-    private static void makeDesc(StringBuffer sbuf, Class<?> type) {
+    private static void makeDesc(StringBuilder sbuf, Class<?> type) {
         if (type.isArray()) {
             sbuf.append('[');
             makeDesc(sbuf, type.getComponentType());


### PR DESCRIPTION
Replace most uses of StringBuffer with StringBuilder to avoid the unnecessary synchronization from StringBuffer.
Replaced string concatenation within an append with multiple appends.
Remove unnecessary toString() calls on String instances.
Change length 1 string arguments of StringBuilder#append to character append (should have slightly better performance). 