### PR TITLE
Lower requirement for an extra type in constructor to Java 7-

### DIFF
--- a/src/main/javassist/compiler/MemberCodeGen.java
+++ b/src/main/javassist/compiler/MemberCodeGen.java
@@ -648,7 +648,7 @@ public class MemberCodeGen extends CodeGen {
                 throw new CompileError("no such constructor: " + targetClass.getName());
 
             if (declClass != thisClass && AccessFlag.isPrivate(acc)) {
-                if (declClass.getClassFile().getMajorVersion() < ClassFile.JAVA_11
+                if (declClass.getClassFile().getMajorVersion() < ClassFile.JAVA_8
                         || !isFromSameDeclaringClass(declClass, thisClass)) {
                     desc = getAccessibleConstructor(desc, declClass, minfo);
                     bytecode.addOpcode(Opcode.ACONST_NULL); // the last parameter


### PR DESCRIPTION
Evening,
first of all thanks for the great project!

This pull request lowers the requirement for an extra `javaassist.runtime.Inner` type in the target constructor when calling a private constructor from an inner class. This check was introduced in #253 and makes no sense considering that the constructor invocation still works on older jvms like 8. (tested against jvm versions `HotSpot 1.8.0_241-b07`, `HotSpot 11.0.6+8-LTS` and `HotSpot 18-ea+12-613`).

The test setup was as follows:

```java
public class Test {
  private static final class Test1234 {

    private final String a;

    private Test1234(String a) {
      this.a = a;
    }
  }
}
```

The generated class looked like this before the change:

```java
public class Test$Test1234$Invoker_10631572689300 implements InstanceMaker {
  private final Type[] type;
  AtomicReference instance = new AtomicReference();

  Test$Test1234$Invoker_10631572689300(Type[] var1) {
    this.type = var1;
  }

  public Object getInstance(InjectionContext var1) {
    if (this.instance.get() == null) {
      this.instance.set(new Test1234(/*calls to get the required string for the class*/, (Inner)null));
    }

    return this.instance.get();
  }
}
```

And like this after the change:

```java
public class Test$Test1234$Invoker_16422617283600 implements InstanceMaker {
  private final Type[] type;
  AtomicReference instance = new AtomicReference();

  Test$Test1234$Invoker_16422617283600(Type[] var1) {
    this.type = var1;
  }

  public Object getInstance(InjectionContext var1) {
    if (this.instance.get() == null) {
      this.instance.set(new Test1234(/*calls to get the required string for the class*/));
    }

    return this.instance.get();
  }
}
```

The code after the change works as expected allowing me to call the private Constructor from the inner class while the code before the change obviously doesn't as there is no constructor with the `String, Inner` signature

I was unable to test this on older jvm versions than 8 so i lowered the check to 8.