### PR TITLE
Only wrap the method name if the method doesn't come from the same declaring class

### DIFF
--- a/src/main/javassist/compiler/MemberCodeGen.java
+++ b/src/main/javassist/compiler/MemberCodeGen.java
@@ -667,8 +667,9 @@ public class MemberCodeGen extends CodeGen {
                                                       origDesc);
 
                 acc = AccessFlag.setPackage(acc) | AccessFlag.STATIC;
-                mname = getAccessiblePrivate(mname, origDesc, desc,
-                                             minfo, declClass);
+                if (!isFromSameDeclaringClass(declClass, thisClass))
+                    mname = getAccessiblePrivate(mname, origDesc, desc,
+                        minfo, declClass);
             }
 
         boolean popTarget = false;


### PR DESCRIPTION
So... I ran into an issue with inner classes again... This time the compiler renames valid method calls when a method is private. The test setup looks like this:

```java
  private static Test1234 test1234(@Name("test") String a) {
    return new Test1234(a);
  }
  ```
  
  When generating an invoker which is an inner class of the `Test` class the compiler will generate this:
  ```java
  public class Test$Invoker_22957570510500 implements InstanceMaker {
      private final Type[] type;

      Test$Invoker_22957570510500(Type[] var1) {
        this.type = var1;
      }

      public Object getInstance(InjectionContext var1) {
        return Test.access$1(/*code to get the string instance*/);
      }
}
```

but the invocation would work perfectly fine as the caller is an inner class of the Test class and allowed to call the method in that way. After the change the compiler generates this method:

```java
  public class Test$Invoker_22957570510500 implements InstanceMaker {
      private final Type[] type;

      Test$Invoker_22957570510500(Type[] var1) {
        this.type = var1;
      }

      public Object getInstance(InjectionContext var1) {
        return Test.test1234(/*code to get the string instance*/);
      }
}
```

which is exactly what i was expecting to get and which works perfectly fine. This change was tested against jvm versions `HotSpot 1.8.0_241-b07`, `HotSpot 11.0.6+8-LTS` and `HotSpot 18-ea+12-613`