### PR TITLE
Fix for NullPointerException on detach()

### DIFF
--- a/src/main/javassist/CtClass.java
+++ b/src/main/javassist/CtClass.java
@@ -1423,7 +1423,7 @@ public abstract class CtClass {
     public void detach() {
         ClassPool cp = getClassPool();
         CtClass obj = cp.removeCached(getName());
-        if (obj != this)
+        if (obj != null && obj != this)
             cp.cacheCtClass(getName(), obj, false);
     }
 


### PR DESCRIPTION
When a `detach()` is invoked on a `CtClass` object, it throws a `NullPointerException` as mentioned in #370 and  in #258, I have seen your response but I don't think it is a good practice to let users receive unexpected `NullPointerException`s. It is not specifically twice `detach()` invocations in a row that results in that error. My code calls `ClassPool.getDefault().get()` once and detaches it safely, however, once I perform that cycle again it results in `NullPointerException`. As I understand from the documentation `ClassPool#get(String)` reads from the class file and returns `CtClass` object and on the other hand, `detach()` causes that `CtClass` object to be removed from the cache. It is a natural expectation that a new `CtClass` object should be created by reading the `.class` file once again when user calls `ClassPool.getDefault().get(String)` and it must allow users to safely detach from the class pool. 

My fix is just a no-brainer, and probably just evades the problem rather than solving it. 