### PR TITLE
Fix MemberResolver.lookupMethod bug when super class has more precise…

### DIFF
--- a/src/main/javassist/compiler/MemberResolver.java
+++ b/src/main/javassist/compiler/MemberResolver.java
@@ -130,9 +130,7 @@ public class MemberResolver implements TokenId {
 
         if (onlyExact)
             maybe = null;
-        else
-            if (maybe != null)
-                return maybe;
+        //else maybe super class has more precise match
 
         int mod = clazz.getModifiers();
         boolean isIntf = Modifier.isInterface(mod);
@@ -143,8 +141,11 @@ public class MemberResolver implements TokenId {
                 if (pclazz != null) {
                     Method r = lookupMethod(pclazz, methodName, argTypes,
                                             argDims, argClassNames, onlyExact);
-                    if (r != null)
-                        return r;
+                    if (r != null) {
+                        if (maybe == null || maybe.notmatch > r.notmatch) {
+                            maybe = r;
+                        }
+                    }
                 }
             }
         }
@@ -156,8 +157,11 @@ public class MemberResolver implements TokenId {
                 Method r = lookupMethod(intf, methodName,
                         argTypes, argDims, argClassNames,
                         onlyExact);
-                if (r != null)
-                    return r;
+                if (r != null) {
+                    if (maybe == null || maybe.notmatch > r.notmatch) {
+                        maybe = r;
+                    }
+                }
             }
 
             if (isIntf) {
@@ -166,8 +170,11 @@ public class MemberResolver implements TokenId {
                 if (pclazz != null) {
                     Method r = lookupMethod(pclazz, methodName, argTypes,
                                             argDims, argClassNames, onlyExact);
-                    if (r != null)
-                        return r;
+                    if (r != null) {
+                        if (maybe == null || maybe.notmatch > r.notmatch) {
+                            maybe = r;
+                        }
+                    }
                 }
             }
         }

--- a/src/test/javassist/SuperCallCase.java
+++ b/src/test/javassist/SuperCallCase.java
@@ -1,0 +1,38 @@
+package javassist;
+
+class Animal {
+}
+
+class Bear extends Animal {
+}
+
+
+/**
+ * Base class has a method with precise type.
+ */
+class Man {
+    String feed(Bear bear) {
+        return "Man feed(Bear)";
+    }
+}
+
+/**
+ * Derived class has a method which has same name with base class's and more imprecise type.
+ */
+class Keeper extends Man {
+    String feed(Animal animal) {
+        return "Keeper feed(Animal)";
+    }
+}
+
+/**
+ * Derived class has a method which call super method with precise type.
+ */
+class BearKeeper extends Keeper {
+    public BearKeeper() {
+    }
+
+    String javacResult() {
+        return super.feed(new Bear());
+    }
+}


### PR DESCRIPTION
… match

When onlyExact=false and super class have a more precise match, it should not return with current class's maybe result.

New added testSuperCall reveals the problem.