### PR TITLE
Remove DUP check in TransformNewClass

### DIFF
--- a/src/main/javassist/convert/TransformNewClass.java
+++ b/src/main/javassist/convert/TransformNewClass.java
@@ -56,9 +56,6 @@ final public class TransformNewClass extends Transformer {
         if (c == NEW) {
             index = iterator.u16bitAt(pos + 1);
             if (cp.getClassInfo(index).equals(classname)) {
-                if (iterator.byteAt(pos + 3) != DUP)
-                    throw new CannotCompileException(
-                                "NEW followed by no DUP was found");
 
                 if (newClassIndex == 0)
                     newClassIndex = cp.addClassInfo(newClassName);


### PR DESCRIPTION
DUP usually come after NEW, but not necessary.

#453