### PR TITLE
Fix insertAuxInitializer may cause inconsistent stack height problem

### DIFF
--- a/src/main/javassist/CtClassType.java
+++ b/src/main/javassist/CtClassType.java
@@ -1763,8 +1763,7 @@ class CtClassType extends CtClass {
         int pos = it.insertEx(initializer.get());
         it.insert(initializer.getExceptionTable(), pos);
         int maxstack = codeAttr.getMaxStack();
-        if (maxstack < stacksize)
-            codeAttr.setMaxStack(stacksize);
+        codeAttr.setMaxStack(maxstack + stacksize);
     }
 
     private int makeFieldInitializer(Bytecode code, CtClass[] parameters)


### PR DESCRIPTION
Usually, constructor only load super class's constructor's init params into stack. After this() or super() called, stack will be empty. If so, we insertAuxInitializer right after this() or super() can reuse max stack size if it enough.

But, there is some weird class out there, their constructors load all in-constructor init field value into stack before this() or super() call. In this case, after this() or super() call, stack is not empty, even maybe full.

In summary, insertAuxInitializer should increase MaxStack anyway.

https://github.com/Tencent/Shadow/issues/1196