### PR TITLE
Minimal changes make IDEA 2023.2 work out-of-box

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
           <testSource>11</testSource>
           <testTarget>11</testTarget>
           <testCompilerArgument>-parameters</testCompilerArgument>

--- a/src/test/javassist/Bench.java
+++ b/src/test/javassist/Bench.java
@@ -5,9 +5,6 @@ import javassist.expr.*;
 import javassist.compiler.*;
 
 public class Bench extends JvstTestRoot {
-    public Bench(String name) {
-        super(name);
-    }
 
     public void testProceed() throws Exception {
         CtClass cc = sloader.get("test.BenchProceed");

--- a/src/test/javassist/JvstTest.java
+++ b/src/test/javassist/JvstTest.java
@@ -20,9 +20,6 @@ public class JvstTest extends JvstTestRoot {
         java9 = javassist.bytecode.ClassFile.MAJOR_VERSION
                     >= javassist.bytecode.ClassFile.JAVA_9;
     }
-    public JvstTest(String name) {
-         super(name);
-    }
 
     public void testConfig() {
         // is the value of PATH correct?

--- a/src/test/javassist/JvstTest2.java
+++ b/src/test/javassist/JvstTest2.java
@@ -14,9 +14,6 @@ import test2.DefineClassCapability;
 @SuppressWarnings({"rawtypes","unused"})
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class JvstTest2 extends JvstTestRoot {
-    public JvstTest2(String name) {
-         super(name);
-    }
 
     public void testInsertAt() throws Exception {
         CtClass cc = sloader.get("test2.InsertAt");

--- a/src/test/javassist/JvstTest3.java
+++ b/src/test/javassist/JvstTest3.java
@@ -7,9 +7,6 @@ import test3.*;
 
 @SuppressWarnings({"rawtypes","unchecked","unused"})
 public class JvstTest3 extends JvstTestRoot {
-    public JvstTest3(String name) {
-         super(name);
-    }
 
     public void testAnnotation() throws Exception {
         CtClass cc = sloader.get("test3.AnnoTest");

--- a/src/test/javassist/JvstTest4.java
+++ b/src/test/javassist/JvstTest4.java
@@ -16,9 +16,6 @@ import javassist.expr.*;
 @SuppressWarnings({"rawtypes","unchecked","unused"})
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class JvstTest4 extends JvstTestRoot {
-    public JvstTest4(String name) {
-        super(name);
-    }
 
     public void testInsertLocalVars() throws Exception {
         CtClass cc = sloader.get("test4.LocalVars");

--- a/src/test/javassist/JvstTest5.java
+++ b/src/test/javassist/JvstTest5.java
@@ -25,9 +25,6 @@ import junit.framework.Assert;
 
 @SuppressWarnings({"rawtypes","unchecked","unused"})
 public class JvstTest5 extends JvstTestRoot {
-    public JvstTest5(String name) {
-        super(name);
-    }
 
     public void testDollarClassInStaticMethod() throws Exception {
         CtClass cc = sloader.makeClass("test5.DollarClass");

--- a/src/test/javassist/JvstTestRoot.java
+++ b/src/test/javassist/JvstTestRoot.java
@@ -13,10 +13,6 @@ public class JvstTestRoot extends TestCase {
     ClassPool sloader, dloader;
     Loader cloader;
 
-    public JvstTestRoot(String name) {
-        super(name);
-    }
-
     protected void print(String msg) {
         System.out.println(msg);
     }

--- a/src/test/javassist/bytecode/InsertGap0.java
+++ b/src/test/javassist/bytecode/InsertGap0.java
@@ -159,9 +159,6 @@ final class Gap0Example2 {
 
 @SuppressWarnings({"rawtypes","unchecked","unused"})
 public final class InsertGap0 extends JvstTestRoot {
-    public InsertGap0(String name) {
-        super(name);
-    }
 
     public void testExample() throws Throwable {
         ClassPool pool = ClassPool.getDefault();


### PR DESCRIPTION
Correct maven-compiler-plugin JDK version for IDEA import Compiler bytecode version.

Remove JvstTestRoot's constructor, otherwise IDEA cannot show Run icon aside testMethod. Another way is adding suite() static method to those classes.

Now we can clone and open project with IDEA 2023.2. Debug single test case with IDEA is very useful.

BTW, some test case failed in IDEA due to some file path problem.
<img width="1279" alt="image" src="https://github.com/jboss-javassist/javassist/assets/3535204/7f7bc18c-454a-4bab-8e3c-104eb26052cb">
