### PR TITLE
Fix bytecode compatible back to 52(JDK8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <testSource>11</testSource>
           <testTarget>11</testTarget>
           <testCompilerArgument>-parameters</testCompilerArgument>


### PR DESCRIPTION
This project need JDK 11 to compile, but target to JDK 8.

IDEA need uncheck "use --release" in Preferences |
Build, Execution, Deployment | Compiler | Java Compiler
, to build success.


fix #470