### PR TITLE
add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+tab_width = 8
+indent_size = 2
+ij_continuation_indent_size = 4
+indent_style = space
+
+trim_trailing_whitespace = true
+
+
+[*.{java,j}]
+indent_size = 4
+ij_continuation_indent_size = 8
+
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Ease the view and edit settings of the editor/IDE.

--------

The files in the `javassist` project(e.g. `.java`, `.xml`) contain tab, and use 8 spaces as tab width;

Add `.editorconfig` file, so no need adjust the editor/IDE settings to ensure the tab width.
(the recent versions of `IntelliJ IDEA` and `GitHub` come bundled with native support for `EditorConfig`.)

--------

More info see https://editorconfig.org/