### PR TITLE
support bootstrap method coping when using code coping

### DIFF
--- a/src/main/javassist/bytecode/BootstrapMethodsAttribute.java
+++ b/src/main/javassist/bytecode/BootstrapMethodsAttribute.java
@@ -2,6 +2,7 @@ package javassist.bytecode;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 public class BootstrapMethodsAttribute extends AttributeInfo {
@@ -35,6 +36,26 @@ public class BootstrapMethodsAttribute extends AttributeInfo {
          * <code>bootstrap_arguments</code>.
          */
         public int[] arguments;
+
+        /**
+         * Makes a copy.  Class names are replaced according to the
+         *          * given <code>Map</code> object.
+         *
+         * @param srcCp     the constant pool table from the source
+         * @param destCp    the constant pool table used bt new copy
+         * @param classnames    pairs of replaced and substituted class names.
+         *
+         * @return new BootstrapMethod
+         */
+        protected BootstrapMethod copy(ConstPool srcCp, ConstPool destCp, Map<String,String> classnames) {
+            int newMethodRef = srcCp.copy(methodRef, destCp, classnames);
+            int[] newArguments = new int[arguments.length];
+
+            for (int i = 0; i < arguments.length; i++)
+                newArguments[i] = srcCp.copy(arguments[i], destCp, classnames);
+
+            return new BootstrapMethod(newMethodRef, newArguments);
+        }
     }
 
     BootstrapMethodsAttribute(ConstPool cp, int n, DataInputStream in)
@@ -51,25 +72,8 @@ public class BootstrapMethodsAttribute extends AttributeInfo {
      */
     public BootstrapMethodsAttribute(ConstPool cp, BootstrapMethod[] methods) {
         super(cp, tag);
-        int size = 2;
-        for (int i = 0; i < methods.length; i++)
-            size += 4 + methods[i].arguments.length * 2;
 
-        byte[] data = new byte[size];
-        ByteArray.write16bit(methods.length, data, 0);    // num_bootstrap_methods
-        int pos = 2;
-        for (int i = 0; i < methods.length; i++) {
-            ByteArray.write16bit(methods[i].methodRef, data, pos);
-            ByteArray.write16bit(methods[i].arguments.length, data, pos + 2);
-            int[] args = methods[i].arguments;
-            pos += 4;
-            for (int k = 0; k < args.length; k++) {
-                ByteArray.write16bit(args[k], data, pos);
-                pos += 2;
-            }
-        }
-
-        set(data);
+        set(convertMethodsToBytes(methods));
     }
 
     /**
@@ -113,12 +117,67 @@ public class BootstrapMethodsAttribute extends AttributeInfo {
         BootstrapMethod[] methods = getMethods();
         ConstPool thisCp = getConstPool();
         for (int i = 0; i < methods.length; i++) {
-            BootstrapMethod m = methods[i];
-            m.methodRef = thisCp.copy(m.methodRef, newCp, classnames);
-            for (int k = 0; k < m.arguments.length; k++)
-                m.arguments[k] = thisCp.copy(m.arguments[k], newCp, classnames);
+            methods[i] = methods[i].copy(thisCp, newCp, classnames);
         }
 
         return new BootstrapMethodsAttribute(newCp, methods);
+    }
+
+    /**
+     * add bootstrap method from given <code>ConstPool</code> and <code>BootstrapMethod</code>,
+     * and add it to the specified index. Class names are replaced according to the
+     * given <code>Map</code> object.
+     *
+     * <p>
+     *      if the index less than 0 or large than the origin method length, then throw <code>RuntimeException</code>;<br>
+     *      if the index large or equals to 0 and less or equals to the origin method length,
+     *          then replace the origin method with the new <code>BootstrapMethod srcBm</code> ;<br>
+     *      if the index equals to the origin method length, then append the new <code>BootstrapMethod srcBm</code> at
+     *          the origin methods tail.
+     * </p>
+     *
+     * @param srcCp     the constant pool table of source.
+     * @param srcBm     the bootstrap method of source
+     * @param index     the new method index on bootstrap methods
+     * @param classnames        pairs of replaced and substituted
+     *                          class names.
+     */
+    public void addMethod(ConstPool srcCp, BootstrapMethod srcBm, int index, Map<String,String> classnames) {
+        BootstrapMethod[] methods = getMethods();
+
+        if (index < 0 || index > methods.length) {
+            throw new RuntimeException("index out of range");
+        }
+
+        if (index == methods.length) {
+            BootstrapMethod[] newBmArray = new BootstrapMethod[methods.length + 1];
+            System.arraycopy(methods, 0, newBmArray, 0, methods.length);
+            methods = newBmArray;
+        }
+
+        methods[index] = srcBm.copy(srcCp, getConstPool(), classnames);
+        set(convertMethodsToBytes(methods));
+    }
+
+    private static byte[] convertMethodsToBytes(BootstrapMethod[] methods) {
+        int size = 2;
+        for (int i = 0; i < methods.length; i++)
+            size += 4 + methods[i].arguments.length * 2;
+
+        byte[] data = new byte[size];
+        ByteArray.write16bit(methods.length, data, 0);    // num_bootstrap_methods
+        int pos = 2;
+        for (int i = 0; i < methods.length; i++) {
+            ByteArray.write16bit(methods[i].methodRef, data, pos);
+            ByteArray.write16bit(methods[i].arguments.length, data, pos + 2);
+            int[] args = methods[i].arguments;
+            pos += 4;
+            for (int k = 0; k < args.length; k++) {
+                ByteArray.write16bit(args[k], data, pos);
+                pos += 2;
+            }
+        }
+
+        return data;
     }
 }

--- a/src/test/javassist/bytecode/BytecodeTest.java
+++ b/src/test/javassist/bytecode/BytecodeTest.java
@@ -6,6 +6,7 @@ import junit.framework.*;
 import javassist.*;
 import javassist.bytecode.annotation.*;
 import javassist.bytecode.SignatureAttribute.*;
+import test4.InvokeDynCopyDest;
 
 @SuppressWarnings("unused")
 public class BytecodeTest extends TestCase {
@@ -461,19 +462,19 @@ public class BytecodeTest extends TestCase {
 
     public void testSignatureChange() throws Exception {
         changeMsig("<S:Ljava/lang/Object;>(TS;[TS;)Ljava/lang/Object", "java/lang/Object",
-                   "<S:Ljava/lang/Objec;>(TS;[TS;)Ljava/lang/Object", "java/lang/Objec"); 
+                   "<S:Ljava/lang/Objec;>(TS;[TS;)Ljava/lang/Object", "java/lang/Objec");
         changeMsig("<S:Ljava/lang/Object;>(TS;[TS;)TT;", "java/lang/Object",
-                   "<S:Ljava/lang/Objec;>(TS;[TS;)TT;", "java/lang/Objec"); 
+                   "<S:Ljava/lang/Objec;>(TS;[TS;)TT;", "java/lang/Objec");
         changeMsig("<S:Ljava/lang/Object;>(TS;[TS;)Ljava/lang/Object2;", "java/lang/Object",
-                   "<S:Ljava/lang/Objec;>(TS;[TS;)Ljava/lang/Object2;", "java/lang/Objec"); 
+                   "<S:Ljava/lang/Objec;>(TS;[TS;)Ljava/lang/Object2;", "java/lang/Objec");
         changeMsig("<S:Ljava/lang/Object;>(TS;[TS;)Ljava/lang/Objec;", "java/lang/Object",
-                   "<S:Ljava/lang/Object2;>(TS;[TS;)Ljava/lang/Objec;", "java/lang/Object2"); 
+                   "<S:Ljava/lang/Object2;>(TS;[TS;)Ljava/lang/Objec;", "java/lang/Object2");
         changeMsig2("<S:Ljava/lang/Object;>(TS;[TS;)TT;", "java/lang/Object",
-                    "<S:Ljava/lang/Objec;>(TS;[TS;)TT;", "java/lang/Objec"); 
+                    "<S:Ljava/lang/Objec;>(TS;[TS;)TT;", "java/lang/Objec");
         changeMsig2("<S:Ljava/lang/Object;>(TS;[TS;)Ljava/lang/Object2;", "java/lang/Object",
-                    "<S:Ljava/lang/Objec;>(TS;[TS;)Ljava/lang/Object2;", "java/lang/Objec"); 
+                    "<S:Ljava/lang/Objec;>(TS;[TS;)Ljava/lang/Object2;", "java/lang/Objec");
         changeMsig2("<S:Ljava/lang/Object;>(TS;[TS;)Ljava/lang/Objec;", "java/lang/Object",
-                    "<S:Ljava/lang/Object2;>(TS;[TS;)Ljava/lang/Objec;", "java/lang/Object2"); 
+                    "<S:Ljava/lang/Object2;>(TS;[TS;)Ljava/lang/Objec;", "java/lang/Object2");
         String sig = "<T:Ljava/lang/Exception;>LPoi$Foo<Ljava/lang/String;>;LBar;LBar2;";
         String res = "<T:Ljava/lang/Exception;>LPoi$Foo<Ljava/lang/String2;>;LBar;LBar2;";
         changeMsig(sig, "java/lang/String", res, "java/lang/String2");
@@ -683,7 +684,7 @@ public class BytecodeTest extends TestCase {
         assertFalse(fi1.equals(fi3));
         assertFalse(fi1.equals(ci1));
         assertFalse(fi1.equals(null));
-       
+
         LongInfo li1 = new LongInfo(12345L, n++);
         LongInfo li2 = new LongInfo(12345L, n++);
         LongInfo li3 = new LongInfo(-12345L, n++);
@@ -832,6 +833,28 @@ public class BytecodeTest extends TestCase {
         assertEquals("test4.InvokeDyn", cc2.getClassFile().getName());
         ConstPool cPool2 = cc2.getClassFile().getConstPool();
         assertEquals("(I)V", cPool2.getUtf8Info(cPool2.getMethodTypeInfo(mtIndex)));
+    }
+
+    public void testInvokeDynamicWithCopy() throws Exception {
+        CtClass srcCc = loader.get("test4.InvokeDynCopySrc");
+        CtClass destCc = loader.get("test4.InvokeDynCopyDest");
+
+        // copy source constructor to dest
+        for (CtConstructor constructor : destCc.getConstructors()) {
+            for (CtConstructor srcClassConstructor : srcCc.getConstructors()) {
+                if (constructor.getSignature().equalsIgnoreCase(srcClassConstructor.getSignature())) {
+                    constructor.setBody(srcClassConstructor, null);
+                }
+            }
+        }
+
+        // set dest class method body by source class
+        destCc.getDeclaredMethod("getString").setBody(srcCc.getDeclaredMethod("getString"), new ClassMap());
+
+        Object destObj = (new Loader(loader)).loadClass(destCc.getName()).getConstructor().newInstance();
+
+        // if don't copy bootstrap method and static lambda method it will throw exception when invoke
+        assertEquals("hello", destObj.getClass().getMethod("getString").invoke(destObj));
     }
 
     public static Test suite() {

--- a/src/test/test4/InvokeDynCopyDest.java
+++ b/src/test/test4/InvokeDynCopyDest.java
@@ -1,0 +1,11 @@
+package test4;
+
+public class InvokeDynCopyDest {
+    public InvokeDynCopyDest() {
+        System.out.println("my output:" + getString());
+    }
+
+    public String getString() {
+        return "dest";
+    }
+}

--- a/src/test/test4/InvokeDynCopySrc.java
+++ b/src/test/test4/InvokeDynCopySrc.java
@@ -1,0 +1,17 @@
+package test4;
+
+import java.util.function.Supplier;
+
+public class InvokeDynCopySrc {
+    public InvokeDynCopySrc() {
+        System.out.println("source class:" + getString());
+    }
+
+    public String getString() {
+        Supplier<String> stringSupplier = () -> {
+            return "hello";
+        };
+
+        return stringSupplier.get();
+    }
+}


### PR DESCRIPTION
Hello, I'm using javassist recently, and I really like the function it provides to copy methods, this makes it very convenient for me to copy the specified method to the target method without having to worry about bytecode writing.

However, during use, it was found that if the method contains lambda expressions or the simple string concatenation(after jdk>=9,after JDK 9, because string concatenation uses BootstrapMethods), it will cause compilation errors or runtime errors.
I looked through the relevant information but not much. I also saw someone mentioning issue(#388 ) related to this.
### **Cause:**
I looked at the source code myself and found that when copying the invoke dynamic operator, only the data of the constant pool was copied, and the bootstrap method was not copied.This will cause errors if there is no corresponding bootstrap method in the target class.

### **Solution:**
When copying the invoke dynamic operator, find the bootstrap method based on the bootstrap method index in the source class and overwrite or add the bootstrap method to the new bootstrap method index in the destination class. In order to prevent the loss of static methods generated by some lambdas, after copying the bootstrap method, the static methods referenced in the source class are also copied to the target class.

I have personally evaluated the new code and it should not affect other operations, and it provides great convenience when using the code copy function. but I am not sure whether it violates the design intention of javassist. Thanks for the discussion and review.