### PR TITLE
[bugfix]fix TransformCallToStatic with invokeinterface or invokedynamic

### DIFF
--- a/src/main/javassist/convert/TransformCallToStatic.java
+++ b/src/main/javassist/convert/TransformCallToStatic.java
@@ -23,6 +23,9 @@ public class TransformCallToStatic extends TransformCall {
         }
         iterator.writeByte(Opcode.INVOKESTATIC, pos);
         iterator.write16bit(newIndex, pos + 1);
+        if (c == Opcode.INVOKEINTERFACE || c == Opcode.INVOKEDYNAMIC) {
+            iterator.writeByte(0, pos + 3);
+        }
         return pos;
     }
 }


### PR DESCRIPTION
Replacing invokeinterface or invokedynamic with invokestatic will result in a missing instruction. This solution can fix the problem.
Reference document:
https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokestatic
https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokedynamic
https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokeinterface