### PR TITLE
reduced InnerClasses propagation

### DIFF
--- a/src/main/javassist/CtClassType.java
+++ b/src/main/javassist/CtClassType.java
@@ -932,14 +932,17 @@ class CtClassType extends CtClass {
         ClassFile cf2 = c.getClassFile2();
         InnerClassesAttribute ica = (InnerClassesAttribute)cf.getAttribute(
                                                 InnerClassesAttribute.tag);
+        InnerClassesAttribute ica2 = new InnerClassesAttribute(cf2.getConstPool());
+        int flags = (cf2.getAccessFlags() & ~AccessFlag.SUPER) | AccessFlag.STATIC;
+
         if (ica == null) {
             ica = new InnerClassesAttribute(cf.getConstPool());
             cf.addAttribute(ica);
         }
 
-        ica.append(c.getName(), this.getName(), name,
-                   (cf2.getAccessFlags() & ~AccessFlag.SUPER) | AccessFlag.STATIC);
-        cf2.addAttribute(ica.copy(cf2.getConstPool(), null));
+        ica.append(c.getName(), this.getName(), name, flags);
+        ica2.append(c.getName(), this.getName(), name, flags);
+        cf2.addAttribute(ica2);
         return c;
     }
 

--- a/src/test/javassist/JvstTest5.java
+++ b/src/test/javassist/JvstTest5.java
@@ -643,4 +643,28 @@ public class JvstTest5 extends JvstTestRoot {
         //expected:<Man feed(Bear)> but was:<Keeper feed(Animal)>
         assertEquals(javacResult, javassistResult);
     }
+
+    public void testMultipleNestedClasses() throws Exception {
+        CtClass outer = sloader.makeClass("javassist.MultipleNestedClasses");
+        CtClass nested1 = outer.makeNestedClass("Nested1", true);
+        CtClass nested2 = outer.makeNestedClass("Nested2", true);
+
+        InnerClassesAttribute outerICA = (InnerClassesAttribute)
+                outer.getClassFile2().getAttribute(InnerClassesAttribute.tag);
+        assertEquals(2, outerICA.tableLength());
+        assertEquals("javassist.MultipleNestedClasses$Nested1", outerICA.innerClass(0));
+        assertEquals("javassist.MultipleNestedClasses$Nested2", outerICA.innerClass(1));
+
+        InnerClassesAttribute nested1ICA = (InnerClassesAttribute)
+                nested1.getClassFile2().getAttribute(InnerClassesAttribute.tag);
+        assertEquals(1, nested1ICA.tableLength());
+        assertEquals("javassist.MultipleNestedClasses", nested1ICA.outerClass(0));
+        assertEquals("javassist.MultipleNestedClasses$Nested1", nested1ICA.innerClass(0));
+
+        InnerClassesAttribute nested2ICA = (InnerClassesAttribute)
+                nested2.getClassFile2().getAttribute(InnerClassesAttribute.tag);
+        assertEquals(1, nested2ICA.tableLength());
+        assertEquals("javassist.MultipleNestedClasses", nested2ICA.outerClass(0));
+        assertEquals("javassist.MultipleNestedClasses$Nested2", nested2ICA.innerClass(0));
+    }
 }


### PR DESCRIPTION
Hello from Airbnb!

We're using javassist to generate a large number of classfiles. It's been a great fit for our needs so far, thanks for sharing this library!

I ran into an issue where creating a class with a large number of nested classes was generating enormous class files and would frequently run out of memory. I think the issue is in `CtClassType.makeNestedClass`, which copies the entire `InnerClassesAttribute` from the outer class into inner classes.

This has the result of taking n**2 space relative to the number of nested classes. This behavior is also not what javac does (see [example](https://gist.github.com/jbellenger/a3aabd2226010322893847ced590d119), particularly the "InnerClasses" at the very bottom which does not include sibling classes).

This PR changes `makeNestedClass` to only copy the outer-nested relationship into the new nested class' InnerClassesAttribute. I wasn't sure where to add a test for this so I put one into JvstTest5 hoping that someone will tell me where this really belongs.