### PR TITLE
Fix wrong line numbers in some cases

### DIFF
--- a/src/main/javassist/bytecode/LineNumberAttributeBuilder.java
+++ b/src/main/javassist/bytecode/LineNumberAttributeBuilder.java
@@ -11,15 +11,15 @@ import java.util.Map;
 public class LineNumberAttributeBuilder {
     private final HashMap<Integer, Integer> map = new HashMap<>();
 
-    public void put(int newPc, ASTree tree) {
+    public void put(int pc, ASTree tree) {
         if (tree != null)
-            put(newPc, tree.getLineNumber());
+            put(pc, tree.getLineNumber());
     }
 
-    private void put(int newPc, int lineNum) {
-        Integer pc = map.get(lineNum);
-        if (pc == null || newPc < pc) {
-            map.put(lineNum, newPc);
+    private void put(int pc, int lineNum) {
+        Integer oldLineNum = map.get(pc);
+        if (oldLineNum == null || lineNum > oldLineNum) {
+            map.put(pc, lineNum);
         }
     }
 
@@ -29,8 +29,8 @@ public class LineNumberAttributeBuilder {
              DataOutputStream dos = new DataOutputStream(bos)) {
             dos.writeShort(size);
             for (Map.Entry<Integer, Integer> entry : map.entrySet()) {
-                dos.writeShort(entry.getValue());
                 dos.writeShort(entry.getKey());
+                dos.writeShort(entry.getValue());
             }
             return new LineNumberAttribute(cp, bos.toByteArray());
         } catch (IOException e) {

--- a/src/test/javassist/LineNumberTest.java
+++ b/src/test/javassist/LineNumberTest.java
@@ -59,6 +59,24 @@ public class LineNumberTest extends TestCase {
                 "}"), 1, 5);
     }
 
+    public void test16Line() {
+        doTestRuntime(String.join("\n",
+                "public void run() {",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "throwException();",
+                "}"), 1, 16);
+    }
+
     private void doTestCompile(String src, String msg) {
         CtClass testClass = loader.makeClass("javassist.LineNumberCompileTest" + classNumber++);
         try {


### PR DESCRIPTION
Current logic allowed to make multiple entries in line number table for one pc. Usually it works fine as in most cases hashmap iterate by increasing key and only the last entry in line number table for each PC is taken into account. But when one line is <16, and second line is >= 16 (default hashmap capacity) then it will iterated in reverse order, so jvm reports wrong line and test fails. I swapped key & value of map in LineNumberAttributeBuilder, so for one pc can match only one lineNumber.