### PR TITLE
Support delay ExceptionInInitializerError.

### DIFF
--- a/src/main/javassist/runtime/Desc.java
+++ b/src/main/javassist/runtime/Desc.java
@@ -68,8 +68,8 @@ public class Desc {
         throws ClassNotFoundException
     {
         if (useContextClassLoader || USE_CONTEXT_CLASS_LOADER_LOCALLY.get())
-            return Class.forName(name, true, Thread.currentThread().getContextClassLoader());
-        return Class.forName(name);
+            return Class.forName(name, false, Thread.currentThread().getContextClassLoader());
+        return Class.forName(name, false, Desc.class.getClassLoader());
     }
 
     /**


### PR DESCRIPTION
When executing the **CtBehavior.instrument** method, if the replaced code uses the special variable **$class**, then after the **CtBehavior.instrument** method is executed, **$class** will actually compile to `Desc. getClazz(className)`, and the **getClazz** method will ultimately call `Class. forName (name, True, Thread. CurrentThread(). getContextClassLoad())` or `Class. forName (name)`.
However, both of these calling ways will execute static code blocks after class loading. If the static code block throws an exception, the class will not be loaded. So if we choose to only load class and not execute static code blocks, using the following code `Class.forName(name, false, Thread.currentThread().getContextClassLoader())`, we can get the Class object without throwing exceptions, which helps us get the members and other information of the Class.